### PR TITLE
Apply custom query for all contact link field

### DIFF
--- a/simpatec/custom_queries.py
+++ b/simpatec/custom_queries.py
@@ -1,0 +1,12 @@
+import frappe
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def custom_contact_query(doctype, txt, searchfield, start, page_len, filters=None):
+    print("custom_contact_query")
+    contacts = frappe.db.get_list("Contact", 
+                filters=[["name", "like", "%" + txt + "%"]], 
+                limit=page_len, 
+                fields=["name as value", "email_id as description"], as_list=True)
+    return contacts

--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -188,3 +188,6 @@ user_data_fields = [
 #	"simpatec.auth.validate"
 # ]
 
+standard_queries = {
+	"Contact": "simpatec.custom_queries.custom_contact_query"
+}


### PR DESCRIPTION
Applies a custom query for all link field for Contact doctype.

The problem was that when selecting a Contact link field, the system fetched all the records (62k+). The reason is unknown, but possibly has something to do with the amount of records. This custom query solves this problem by limiting the fetching to 20 records.
