### PR TITLE
apply custom filter to contact link field

### DIFF
--- a/simpatec/custom_queries.py
+++ b/simpatec/custom_queries.py
@@ -4,9 +4,13 @@ import frappe
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def custom_contact_query(doctype, txt, searchfield, start, page_len, filters=None):
-    print("custom_contact_query")
+    f = [["name", "like", "%" + txt + "%"]]
+    if filters:
+        f.extend(filters)
+    filters = f
+
     contacts = frappe.db.get_list("Contact", 
-                filters=[["name", "like", "%" + txt + "%"]], 
+                filters=filters, 
                 limit=page_len, 
                 fields=["name as value", "email_id as description"], as_list=True)
     return contacts


### PR DESCRIPTION
Related to https://github.com/SimpaTec/simpatec/pull/1

## Issue
Contact Filter on Customer Subsidiary not working correctly (Thread)
on Customer Subsidiary there is a Client Script with a filter for a contact. It is applied in the UI but seems to have no effect, as other Contacts are also shown.

## Solution
Now it is possible to set a query like:
```
        frm.set_query("contact_person", function(){
            return {
                "filters": [
                    ["name", "=", "first name 2-Siemens"]
                ]
            }
        });
```
NOTE: the filter should be in the form of an array of arrays, for example: `[["name", "=", "first name 2-Siemens"]]` and NOT the dictionary format like: `{"name": "first name 2-Siemens"}`

and to be applied at the same time as the standard query created with https://github.com/SimpaTec/simpatec/pull/1