### PR TITLE
Issue #10, Software Maintenance and Sales Order Changes

### DIFF
--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -97,7 +97,7 @@ def get_custom_fields():
 	]
 
 
-	custom_fields_si = [
+	custom_fields_so = [
 		{
 			"label": "SimpaTec",
 			"fieldname": "simpatec_section",
@@ -172,5 +172,5 @@ def get_custom_fields():
 
 	return {
 		"Customer": custom_fields_customer,
-		"Sales Order": custom_fields_si
+		"Sales Order": custom_fields_so
 	}

--- a/simpatec/public/js/sales_order.js
+++ b/simpatec/public/js/sales_order.js
@@ -1,5 +1,6 @@
 frappe.ui.form.on('Sales Order', {
     refresh(frm) {
+        $('[data-doctype="Software Maintenance"]').find("button").hide();
         if (frm.doc.sales_order_type == 'First Sale' && frm.doc.docstatus == 1) {
             frm.add_custom_button('Software Maintenance', function () { 
                 frappe.model.open_mapped_doc({

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -13,10 +13,8 @@ class SoftwareMaintenance(Document):
 		if self.sales_order:
 			software_maintenance = frappe.get_cached_value('Sales Order', self.sales_order, 'software_maintenance')
 			if software_maintenance and software_maintenance != self.name:
-				frappe.throw(_('{0} already exist against {1}').format(
-					frappe.get_desk_link("Software Maintenance", software_maintenance), 
-					frappe.get_desk_link("Sales Order", self.sales_order)))
+				frappe.throw(_('Software Maintenance already exist for {0}').format(frappe.get_desk_link("Sales Order", self.sales_order)))
 			
 			if not software_maintenance:
 				frappe.db.set_value('Sales Order', self.sales_order, 'software_maintenance', self.name)
-				frappe.msgprint(_('{0} updated').format(frappe.get_desk_link("Sales Order", self.sales_order)))
+				frappe.msgprint(_('"Software Maintenance" field updated in {0}').format(frappe.get_desk_link("Sales Order", self.sales_order)))

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -6,11 +6,11 @@ from frappe import _
 from frappe.model.document import Document
 
 class SoftwareMaintenance(Document):
-	def on_update(self):
+	def validate(self):
 		self.update_sales_order()
 
 	def update_sales_order(self):
-		if self.sales_order:
+		if self.sales_order and not self.is_new():
 			software_maintenance = frappe.get_cached_value('Sales Order', self.sales_order, 'software_maintenance')
 			if software_maintenance and software_maintenance != self.name:
 				frappe.throw(_('Software Maintenance already exist for {0}').format(frappe.get_desk_link("Sales Order", self.sales_order)))


### PR DESCRIPTION
1. Improved messages on Software Software Maintenance
a. Message when software_maintenance  is updated in Sales Order form:
![image](https://github.com/SimpaTec/simpatec/assets/25414115/b4d33c08-bcca-4aed-95e4-489ec0d836f1)
b. Throw message if Sales Order already have software_maintenance field;
![image](https://github.com/SimpaTec/simpatec/assets/25414115/417104f0-2801-4ff5-b2c3-0fbdc7fde951)

Removed + button from Software Maintenance Badge in Sales Order Dashboard
![image](https://github.com/SimpaTec/simpatec/assets/25414115/036ac2cb-396c-42d7-84f3-25dce97a2e46)