### PR TITLE
FIelds Order Bug Fixing and Filters Modify on Sales Order Field

### DIFF
--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -112,28 +112,28 @@ def get_custom_fields():
 			"insert_after": "simpatec_section"
 		},
 		{
-			"allow_on_submit": 1,
-			"depends_on": "eval:doc.sales_order_type != \"Internal Clearance\"",
+			"label": "Eligable for Clearance",
 			"fieldname": "eligable_for_clearance",
 			"fieldtype": "Check",
+			"allow_on_submit": 1,
+			"depends_on": "eval:doc.sales_order_type != \"Internal Clearance\" && doc.sales_order_type != \"\"",
 			"insert_after": "sales_order_type",
-			"label": "Eligable for Clearance",
 		},
 		{
-			"allow_on_submit": 1,
-			"depends_on": "eval:doc.sales_order_type != \"Internal Clearance\" && doc.eligable_for_clearance == 1",
+			"label": "Internal Clearance Details",
 			"fieldname": "internal_clearance_details",
 			"fieldtype": "Link",
 			"options": "Internal Clearance Details",
-			"insert_after": "sales_order_type",
-			"label": "Internal Clearance Details",
+			"allow_on_submit": 1,
+			"depends_on": "eval:doc.sales_order_type != \"Internal Clearance\" && doc.eligable_for_clearance == 1",
+			"insert_after": "eligable_for_clearance",
 		},
 		{
 			"label": "Item Group",
 			"fieldname": "item_group",
 			"fieldtype": "Link",
 			"options": "Item Group",
-			"insert_after": "eligable_for_clearance"
+			"insert_after": "internal_clearance_details"
 		},
 		{
 			"label": "Performance Period Start",
@@ -143,14 +143,9 @@ def get_custom_fields():
 			"insert_after": "item_group",
 		},
 		{
-			"fieldname": "column_break_5",
-			"fieldtype": "Column Break",
-			"insert_after": "performance_period_start",
-		},
-		{
 			"fieldname": "column_break_fdgxg",
 			"fieldtype": "Column Break",
-			"insert_after": "column_break_5",
+			"insert_after": "performance_period_start",
 		},
 		{
 			"label": "UID",
@@ -194,8 +189,8 @@ def get_custom_fields():
 			"label": "Internal Clearance",
 			"fieldname": "internal_clearance",
 			"fieldtype": "Section Break",
+			"depends_on": "eval:doc.sales_order_type == \"Internal Clearance\"",
 			"insert_after": "ihr_ansprechpartner",
-			"depends_on": "eval:doc.sales_order_type != \"Internal Clearance\"",
 		},
 		{
 			"label": "Sales Order Clearances",

--- a/simpatec/public/js/sales_order.js
+++ b/simpatec/public/js/sales_order.js
@@ -4,8 +4,6 @@ frappe.ui.form.on('Sales Order', {
         frm.set_query('sales_order', 'sales_order_clearances', function () {
             return {
                 filters: {
-                    "name": ["!=", frm.doc.name],
-                    "sales_order_type": ["!=", "Internal Clearance"],
                     "eligable_for_clearance": 1,
                     "docstatus": 1
                 },


### PR DESCRIPTION
### On Selecting Sales Order type **_other than_** Internal Clearance then Eligable for clearance check will appear, if Eligable for clearance is checked then Internal Clearance Details field will appear
<img width="1298" alt="Screenshot 2024-03-15 at 07 52 22" src="https://github.com/SimpaTec/simpatec/assets/14124603/44966df1-5595-42d3-82a5-cc87eabadd06">

### On Selecting Sales Order type **_is_** Internal Clearance then its section will appear.
<img width="806" alt="Screenshot 2024-03-15 at 07 56 30" src="https://github.com/SimpaTec/simpatec/assets/14124603/2900b4a1-c082-4767-a528-36fc593aa5a4">

### after adding details on internal clearance, Item details will update automatically
<img width="1069" alt="Screenshot 2024-03-15 at 08 09 58" src="https://github.com/SimpaTec/simpatec/assets/14124603/d94a499d-b67e-4336-9bce-5492559d91f6">
