### PR TITLE
check-maintenance-banner-on-issue-and-customer

### DIFF
--- a/simpatec/events/api.py
+++ b/simpatec/events/api.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+@frappe.whitelist()
+def software_maintenance(customer):
+    return frappe.get_all('Software Maintenance', filters={'customer': customer}, fields=["name", "status", "performance_period_end"])

--- a/simpatec/events/issue.py
+++ b/simpatec/events/issue.py
@@ -1,6 +1,0 @@
-import frappe
-
-
-@frappe.whitelist()
-def software_maintenance(item_group, customer):
-    return frappe.get_all('Software Maintenance', filters={'item_group': item_group, 'customer': customer}, fields=["name", "status", "performance_period_end"])

--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -32,6 +32,7 @@ app_license = "MIT"
 
 # include js in doctype views
 doctype_js = {
+    "Customer" : "public/js/customer.js",
     "Issue" : "public/js/issue.js",
     "Sales Order" : "public/js/sales_order.js",
 	"Quotation" : "public/js/quotation.js"

--- a/simpatec/public/js/customer.js
+++ b/simpatec/public/js/customer.js
@@ -1,0 +1,42 @@
+frappe.ui.form.on('Customer', {
+	refresh: (frm) => {
+		if(!frm.is_new()) {
+			frm.trigger('make_dashboard');
+		}
+	},
+	make_dashboard: (frm) => {
+		if(!frm.is_new()) {
+			frappe.call({
+				method: 'simpatec.events.api.software_maintenance',
+				args: {customer: frm.doc.name},
+				callback: (r) => {
+					if(!r.message) {
+						return;
+					}
+					(r.message || []).forEach(function(d) {
+
+						let color;
+						if (d.status === 'Active'){
+							color = "green";
+						}
+						else {
+							color = "red";
+						}
+
+						frm.dashboard.set_headline_alert(`
+							<div class="row">
+								<div class="col-xs-12">
+									<span class="indicator whitespace-nowrap ${color}">
+										<span class="hidden-xs">
+											<a style="text-decoration: underline;" onclick="frappe.set_route('Form', 'Software Maintenance', '${d.name}');">The Software Maintenance ${d.name} is <b>${d.status}</b>. Expiry on: <b>${d.performance_period_end}</b>. Click to open</a>
+										</span>
+									</span>
+								</div>
+							</div>
+						`);
+					});
+				}
+			});
+		}
+	}
+})

--- a/simpatec/public/js/issue.js
+++ b/simpatec/public/js/issue.js
@@ -7,10 +7,10 @@ frappe.ui.form.on('Issue', {
 	},
 	make_dashboard: (frm) => {
 		if(!frm.is_new()) {
-            if (frm.doc.customer && frm.doc.item_group) {
+            if (frm.doc.customer) {
                 frappe.call({
-                    method: 'simpatec.events.issue.software_maintenance',
-                    args: {item_group: frm.doc.item_group, customer: frm.doc.customer},
+                    method: 'simpatec.events.api.software_maintenance',
+                    args: {customer: frm.doc.customer},
                     callback: (r) => {
                         if(!r.message) {
                             return;


### PR DESCRIPTION
1. Banner on Issue:
![image](https://github.com/SimpaTec/simpatec/assets/25414115/64160f8f-649c-45dc-a722-d9bcf93d8b62)

2. Banner on Customer
![image](https://github.com/SimpaTec/simpatec/assets/25414115/9aa93fed-47ed-485a-89bb-196ac00ebd7b)

3. Banner with all software maintenance filtered by customer instead of filtered by both item_group and customer