### PR TITLE
Fix for Purchase order and Opportunity doctype

### DIFF
--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -35,8 +35,8 @@ doctype_js = {
     "Issue" : "public/js/issue.js",
     "Sales Order" : "public/js/sales_order.js",
 	"Quotation" : "public/js/quotation.js",
-	"Opportunity": "public/js/opportunity",
-	"Purchase Order" : "public/js/purchser_order.js",
+	"Opportunity": "public/js/opportunity.js",
+	"Purchase Order" : "public/js/purchase_order.js",
 	"Sales Invoice" : "public/js/sales_invoice.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}


### PR DESCRIPTION
Corrected all typo and missing value in hooks file for the doctype js includes

![b33ac62d-403e-4a7a-a9e2-926c0af21fa6](https://github.com/SimpaTec/simpatec/assets/85407202/8db9dd7d-3070-4f36-8b24-7956b75d1b61)
