### PR TITLE
Fix unintended transferred of print language from Sales Order to Purc…

### DIFF
--- a/simpatec/events/purchase_order.py
+++ b/simpatec/events/purchase_order.py
@@ -1,0 +1,13 @@
+import frappe
+from frappe import _
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def validate(doc, handler=None):
+    """"""
+    supplier_lang = frappe.db.get_value('Supplier',doc.supplier,'language')
+    doc.language = supplier_lang
+    
+    for lang in doc.items:
+        lang.item_language = supplier_lang
+        ##print(lang.description)

--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -106,6 +106,9 @@ doc_events = {
 	"Sales Order": {
         "validate": "simpatec.events.sales_order.validate",
 		"on_submit": "simpatec.events.sales_order.update_software_maintenance"
+	},
+	"Purchase Order": {
+		"validate": "simpatec.events.purchase_order.validate",
 	}
 }
 


### PR DESCRIPTION
…hase Order.

issue: https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/11

The Supplier Master has the needed print language therefore our script gets the print value from supplier doctype with the supplier name as the filter. On save of the PO all line items item_language are set from the returned value of the Supplier master that is also set as the purchase order print language.
![poprintlang](https://github.com/SimpaTec/simpatec/assets/85407202/46dcb3ea-d75a-47a9-bd53-50e084443514)
