### PR TITLE
Fix double pop-up dialog on link field select

### DIFF
--- a/simpatec/public/js/opportunity.js
+++ b/simpatec/public/js/opportunity.js
@@ -64,7 +64,7 @@ frappe.ui.form.on('Opportunity Item',{
 		var row = locals[cdt][cdn];
 		if(!(frm.doc.language=== row.item_language)){			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 			
 				frappe.confirm("💬"+__("  The language <b>{0}</b> in the just edited row is different to the others. Should <b>{0}</b> apply to all rows?", [ row.item_language]),
 				()=>{
@@ -78,7 +78,7 @@ frappe.ui.form.on('Opportunity Item',{
 		else if (frm.doc.language=== row.item_language){
 			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 				//				
 				frappe.confirm("💬"+__("    The language <b>'{0}'</b> in the just edited row is different to the others. Should <b>'{0}'</b> apply to all rows?", [ row.item_language]),
 					()=>{

--- a/simpatec/public/js/purchase_order.js
+++ b/simpatec/public/js/purchase_order.js
@@ -64,7 +64,7 @@ frappe.ui.form.on('Purchase Order Item',{
 		var row = locals[cdt][cdn];
 		if(!(frm.doc.language=== row.item_language)){			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 			
 				frappe.confirm("💬"+__("  The language <b>{0}</b> in the just edited row is different to the others. Should <b>{0}</b> apply to all rows?", [ row.item_language]),
 				()=>{
@@ -78,7 +78,7 @@ frappe.ui.form.on('Purchase Order Item',{
 		else if (frm.doc.language=== row.item_language){
 			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 				//				
 				frappe.confirm("💬"+__("    The language <b>'{0}'</b> in the just edited row is different to the others. Should <b>'{0}'</b> apply to all rows?", [ row.item_language]),
 					()=>{

--- a/simpatec/public/js/quotation.js
+++ b/simpatec/public/js/quotation.js
@@ -104,7 +104,7 @@ frappe.ui.form.on('Quotation Item',{
 		var row = locals[cdt][cdn];
 		if(!(frm.doc.language=== row.item_language)){			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 			
 				frappe.confirm("💬"+__("  The language <b>{0}</b> in the just edited row is different to the others. Should <b>{0}</b> apply to all rows?", [ row.item_language]),
 				()=>{
@@ -118,7 +118,7 @@ frappe.ui.form.on('Quotation Item',{
 		else if (frm.doc.language=== row.item_language){
 			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 				//				
 				frappe.confirm("💬"+__("    The language <b>'{0}'</b> in the just edited row is different to the others. Should <b>'{0}'</b> apply to all rows?", [ row.item_language]),
 					()=>{

--- a/simpatec/public/js/sales_invoice.js
+++ b/simpatec/public/js/sales_invoice.js
@@ -64,7 +64,7 @@ frappe.ui.form.on('Sales Invoice Item',{
 		var row = locals[cdt][cdn];
 		if(!(frm.doc.language=== row.item_language)){			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 			
 				frappe.confirm("💬"+__("  The language <b>{0}</b> in the just edited row is different to the others. Should <b>{0}</b> apply to all rows?", [ row.item_language]),
 				()=>{
@@ -78,7 +78,7 @@ frappe.ui.form.on('Sales Invoice Item',{
 		else if (frm.doc.language=== row.item_language){
 			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 				//				
 				frappe.confirm("💬"+__("    The language <b>'{0}'</b> in the just edited row is different to the others. Should <b>'{0}'</b> apply to all rows?", [ row.item_language]),
 					()=>{

--- a/simpatec/public/js/sales_order.js
+++ b/simpatec/public/js/sales_order.js
@@ -146,7 +146,7 @@ frappe.ui.form.on('Sales Order Item',{
 		var row = locals[cdt][cdn];
 		if(!(frm.doc.language=== row.item_language)){			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 			
 				frappe.confirm("💬"+__("  The language <b>{0}</b> in the just edited row is different to the others. Should <b>{0}</b> apply to all rows?", [ row.item_language]),
 				()=>{
@@ -160,7 +160,7 @@ frappe.ui.form.on('Sales Order Item',{
 		else if (frm.doc.language=== row.item_language){
 			
 			let row_occurence = frm.occurence_len(data, row.item_language);
-			if (row_occurence < data.length){
+			if (row_occurence < data.length && !cur_dialog){
 				//				
 				frappe.confirm("💬"+__("    The language <b>'{0}'</b> in the just edited row is different to the others. Should <b>'{0}'</b> apply to all rows?", [ row.item_language]),
 					()=>{


### PR DESCRIPTION
This fix the double pop-up message, when any of the line item, item language is selected

![fixdoublepopup](https://github.com/SimpaTec/simpatec/assets/85407202/874070e9-a71d-49c0-af26-8f1cf5defe06)
