### PR TITLE
Remove all plus add in connection dashbord

### DIFF
--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
@@ -14,5 +14,7 @@ frappe.ui.form.on('Software Maintenance', {
                 },
             });
         }, __("Renew Sales Order"));
+        //hide all + in the connection
+        $('.form-documents button').hide();
     }
 });


### PR DESCRIPTION
To control how user interact with the connection dashboard all + sign are remove and at a later time specific will be dedicated for each doctypes.

 
![image](https://github.com/SimpaTec/simpatec/assets/85407202/44a47b00-a2a4-451d-8496-8794ed608443)
