### PR TITLE
First Sales Reuccurring updates

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -52,6 +52,17 @@ def make_software_maintenance(source_name, target_doc=None):
 	def postprocess(source, doc):
 		if source.sales_order_type == "First Sale":
 			doc.first_sale_on = source.transaction_date
+			for item in doc.items:
+				item.start_date = item.start_date + timedelta(days=365)
+				item.end_date = item.end_date + timedelta(days=365)
+				days_diff = item.end_date - item.start_date
+				if days_diff == 365:
+					item.end_date = item.end_date - timedelta(days=1)
+				so_item = source.items[item.idx-1]
+				if so_item.item_type == "Maintenance Item":
+					item.rate = so_item.reccuring_maintenance_amount
+				else:
+					item.rate = 0
 		doc.assign_to = source.assigned_to
 
 	doc = get_mapped_doc(


### PR DESCRIPTION
Points covered in this PR
- First Sales of Period start date and end date is adding +1 in software maintenance after submission of Sales Order
- when selecting performance start date, end date will automatically populate with +1 year in sales order doctype level.
- In Sales Order, Recurring amount is visible on sales order item when item_type is "Maintenance Item"
- after submitting SO, in software maintenance, item level has the value of Reuccurring amount only for maintenance item.
![recording4](https://github.com/SimpaTec/simpatec/assets/14124603/10f2ef8f-2cb6-4c67-8052-5f279556cb2a)
