### PR TITLE
Follow-Up Scnerio Updates

### DIFF
--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -107,7 +107,7 @@ def get_custom_fields():
 			"label": "Sales Order Type",
 			"fieldname": "sales_order_type",
 			"fieldtype": "Select",
-			"options": "\nFirst Sale\nFollow-Up Sale\nFollow Up Maintenance\nRTO\nSubscription Annual\nInternal Clearance\nOther",
+			"options": "\nFirst Sale\nFollow-Up Sale\nFollow Up Maintenance\nReoccuring Maintenance\nRTO\nSubscription Annual\nInternal Clearance\nOther",
 			"default": "",
 			"insert_after": "simpatec_section"
 		},
@@ -277,6 +277,40 @@ def get_custom_fields():
 	]
 
 	custom_fields_soi = [
+		{
+			"label": "SimpaTec",
+			"fieldname": "simpatec_section",
+			"fieldtype": "Section Break",
+			"insert_after": ""
+		},	
+		{
+			"label": "Item Type",
+			"fieldname": "item_type",
+			"fieldtype": "Data",
+			"fetch_from": "item_code.item_type",
+			"read_only": 1,
+			"fetch_if_empty": 1,
+			"insert_after": "simpatec_section",
+		
+		},
+		{
+			"fieldname": "column_break_vh0vp",
+			"fieldtype": "Column Break",
+			"insert_after": "item_type",
+		},
+		{
+			"label": "Reoccuring Maintenance Amount",
+			"fieldname": "reoccuring_maintenance_amount",
+			"fieldtype": "Currency",
+			"description": "The grand total of the reoccurring maintenance cost",
+			"depends_on": "eval: doc.item_type == \"Maintenance Item\"",
+			"insert_after": "column_break_vh0vp"
+		},
+		{
+			"fieldname": "section_break_kiny4",
+			"fieldtype": "Section Break",
+			"insert_after": "reoccuring_maintenance_amount"
+		},
 		{
 			"label": "Item Language",
 			"fieldname": "item_language",

--- a/simpatec/public/js/sales_order.js
+++ b/simpatec/public/js/sales_order.js
@@ -67,7 +67,7 @@ frappe.ui.form.on('Sales Order', {
                 frm.toggle_enable("software_maintenance", 0)
                 frm.toggle_reqd("software_maintenance", 0)
             } 
-            else if(["Follow-Up Sale", "Follow Up Maintenance"].includes(frm.doc.sales_order_type)) {
+            else if (["Follow-Up Sale", "Reoccuring Maintenance", "Follow Up Maintenance"].includes(frm.doc.sales_order_type)) {
                 frm.toggle_reqd("software_maintenance", 1)
                 frm.toggle_enable("software_maintenance", 1)
             }
@@ -137,7 +137,7 @@ frappe.ui.form.on('Sales Order', {
             // frm.toggle_enable("performance_period_start", 1)
             // frm.toggle_enable("performance_period_end", 1)
         }
-        else if(["Follow-Up Sale", "Follow Up Maintenance"].includes(frm.doc.sales_order_type)) {
+        else if (["Follow-Up Sale", "Reoccuring Maintenance", "Follow Up Maintenance"].includes(frm.doc.sales_order_type)) {
             frm.toggle_reqd("software_maintenance", 1)
             frm.toggle_enable("software_maintenance", 1)
         }
@@ -146,20 +146,20 @@ frappe.ui.form.on('Sales Order', {
             frm.toggle_enable("software_maintenance", 1)
         }
         
-        if(["Follow-Up Sale"].includes(frm.doc.sales_order_type)) {
-            frm.toggle_enable("performance_period_start", 0)
-            frm.toggle_enable("performance_period_end", 0)
-        }else{
-            frm.toggle_enable("performance_period_start", 1)
-            frm.toggle_enable("performance_period_end", 1)
-        }
+        // if(["Follow-Up Sale"].includes(frm.doc.sales_order_type)) {
+        //     frm.toggle_enable("performance_period_start", 0)
+        //     frm.toggle_enable("performance_period_end", 0)
+        // }else{
+        //     frm.toggle_enable("performance_period_start", 1)
+        //     frm.toggle_enable("performance_period_end", 1)
+        // }
 
     },
     performance_period_start: function (frm) {
         var currentDate = moment(frm.doc.performance_period_start);
         var futureMonth = moment(currentDate).add(364, 'd');
         frm.set_value("performance_period_end", futureMonth.format('YYYY-MM-DD'))
-        if (["First Sale", "Reoccurring Maintenance"].includes(frm.doc.sales_order_type)){
+        if (["First Sale", "Follow-Up Sale", "Reoccurring Maintenance"].includes(frm.doc.sales_order_type)){
             $.each(frm.doc.items || [], function (i, d) {
                 if (!d.start_date) d.start_date = frm.doc.performance_period_start;
             });
@@ -173,17 +173,17 @@ frappe.ui.form.on('Sales Order', {
         refresh_field("items");
     },
 
-    software_maintenance: function(frm){
-        if(!is_null(frm.doc.software_maintenance)){
-            if (["Follow-Up Sale"].includes(frm.doc.sales_order_type)) {
-                frm.toggle_enable("performance_period_start",0)
-                frm.toggle_enable("performance_period_end",0)
-            }
-        }else{
-            frm.toggle_enable("performance_period_start", 1)
-            frm.toggle_enable("performance_period_end", 1)
-        }
-    }
+    // software_maintenance: function(frm){
+    //     if(!is_null(frm.doc.software_maintenance)){
+    //         if (["Follow-Up Sale"].includes(frm.doc.sales_order_type)) {
+    //             frm.toggle_enable("performance_period_start",0)
+    //             frm.toggle_enable("performance_period_end",0)
+    //         }
+    //     }else{
+    //         frm.toggle_enable("performance_period_start", 1)
+    //         frm.toggle_enable("performance_period_end", 1)
+    //     }
+    // }
 
 })
 
@@ -234,7 +234,7 @@ frappe.ui.form.on("Sales Order Clearances", {
 
 frappe.ui.form.on('Sales Order Item',{
     item_code: function (frm, cdt, cdn) {
-        if(["First Sale"].includes(frm.doc.sales_order_type)){
+        if (["First Sale", "Follow-Up Sale", "Reoccuring Maintenance","Follow Up Maintenance"].includes(frm.doc.sales_order_type)){
             var row = locals[cdt][cdn];
             if (frm.doc.performance_period_start) {
                 row.start_date = frm.doc.performance_period_start;


### PR DESCRIPTION
- Follow-Up Maintenance Scenerio Covered in this PR
- on selecting the follow-up sales type, dates should be editable
- Dates will be same as performance start/end on doclevel in to the item table
- item level dates should be +1 year into the software maintenance table
![recording4](https://github.com/SimpaTec/simpatec/assets/14124603/6d3c6182-0b24-41b6-a443-1fa212d29047)
