### PR TITLE
Follow-Up Functionality

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -110,11 +110,23 @@ def update_software_maintenance(doc, method=None):
 			else:
 				item.rate = 0
 			if type(item.start_date) == str:
-				item.start_date = datetime.strptime(item.start_date, "%Y-%m-%d")
+				item.start_date = datetime.strptime(item.start_date, "%Y-%m-%d").date()
 			if type(item.end_date) == str:
-				item.end_date = datetime.strptime(item.end_date, "%Y-%m-%d")
+				item.end_date = datetime.strptime(item.end_date, "%Y-%m-%d").date()
 			item.start_date = item.start_date + timedelta(days=365)
 			item.end_date = item.end_date + timedelta(days=365)
+			if doc.sales_order_type == "Follow-Up Sale":
+				item.end_date = software_maintenance.performance_period_end + timedelta(days=365)
+				per_day_rate = item.rate / 365
+				start_date = item.start_date
+				d0 = start_date
+				d1 = item.end_date
+				delta = d1 - d0
+				days_remaining = delta.days
+				total_remaining_item_rate = days_remaining * per_day_rate
+				item.rate = total_remaining_item_rate
+			# expected_end_date = item.end_date + timedelta(days=365)
+
 			days_diff = item.end_date - item.start_date
 			if days_diff == 365:
 				item.end_date = item.end_date - timedelta(days=1)

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
@@ -13,7 +13,23 @@ frappe.ui.form.on('Software Maintenance', {
                 callback: function (r) {
                 },
             });
-        }, __("Renew Sales Order"));
+        }, __("Create Sales Order"));
+
+
+        frm.add_custom_button('Reoccuring Software Maintenance', function () {
+            frappe.call({
+                method: "simpatec.simpatec.doctype.software_maintenance.software_maintenance.make_sales_order",
+                args: {
+                    software_maintenance: frm.doc.name,
+                    is_background_job: 0,
+                    is_reoccuring: 1
+                },
+                callback: function (r) {
+                },
+            });
+        }, __("Create Sales Order"));
+
+
         //hide all + in the connection
         $('.form-documents button').hide();
     }

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint, add_days, add_years, getdate
+from datetime import timedelta
 
 class SoftwareMaintenance(Document):
 
@@ -23,3 +25,71 @@ class SoftwareMaintenance(Document):
 			if not software_maintenance:
 				frappe.db.set_value('Sales Order', self.sales_order, 'software_maintenance', self.name)
 				frappe.msgprint(_("This Software Maintenance has been updated in the respective link field in Sales Order {0} ℹ️".format(frappe.get_desk_link("Sales Order", self.sales_order))))
+
+
+@frappe.whitelist()
+def make_sales_order(software_maintenance, is_background_job=True, is_reoccuring=None):
+	software_maintenance = frappe.get_doc("Software Maintenance", software_maintenance)
+	if not software_maintenance.assign_to:
+		frappe.throw(_("Please set 'Assign to' in Software maintenance '{0}'").format(software_maintenance.name))
+
+	employee =  frappe.get_cached_value('Employee', {'user_id': software_maintenance.assign_to}, 'name')
+	if not employee:
+		frappe.throw(_("User {0} not set in Employee").format(software_maintenance.assign_to))
+	old_start_date = software_maintenance.performance_period_start
+	performance_period_start = add_days(software_maintenance.performance_period_end, 1)
+	performance_period_end = add_years(performance_period_start, software_maintenance.maintenance_duration) - timedelta(days=1)
+	total_days = getdate(performance_period_end) - getdate(performance_period_start)
+
+	days_diff = total_days.days%365
+	if days_diff != 0:
+		_performance_period_end = add_days(performance_period_end, -days_diff)
+		total_days = getdate(_performance_period_end) - getdate(performance_period_start)
+
+	transaction_date = add_days(performance_period_end, -cint(software_maintenance.lead_time))
+	sales_order = frappe.new_doc("Sales Order")
+	sales_order.customer_subsidiary = software_maintenance.customer_subsidiary
+	sales_order.performance_period_start = performance_period_start
+	sales_order.performance_period_end = performance_period_end
+	sales_order.software_maintenance = software_maintenance.name
+	sales_order.item_group = software_maintenance.item_group
+	sales_order.customer = software_maintenance.customer
+	sales_order.sales_order_type = "Reoccuring Maintenance"
+	sales_order.ihr_ansprechpartner = employee
+	sales_order.transaction_date = transaction_date
+	sales_order.order_type = "Sales"
+
+	for item in software_maintenance.items:
+		start_date = performance_period_start
+		item_rate = item.rate
+		if item.start_date != old_start_date:
+			per_day_rate = item.rate / 365
+			start_date = item.end_date
+			d0 = start_date
+			d1 = performance_period_end
+			delta = d1 - d0
+			days_remaining = delta.days
+			total_remaining_item_rate = days_remaining * per_day_rate
+			item_rate = total_remaining_item_rate
+
+		sales_order.append("items", {
+			"item_code": item.item_code,
+			"item_name": item.item_name,
+			"description": item.description,
+			"conversion_factor": item.conversion_factor,
+			"qty": item.qty,
+			"rate": item_rate,
+			"reoccuring_maintenance_amount": item_rate,
+			"uom": item.uom,
+			"item_language": item.item_language,
+			"delivery_date": sales_order.transaction_date,
+			"start_date": start_date,
+			"end_date": performance_period_end
+		})
+
+	sales_order.insert()
+
+	if not cint(is_background_job):
+		frappe.msgprint("Maintenance Duration (Years): {}".format(software_maintenance.maintenance_duration))
+		frappe.msgprint("Maintenance Duration (Days): {}".format(total_days.days))
+		frappe.msgprint(_("New {} Created").format(frappe.get_desk_link("Sales Order", sales_order.name)))


### PR DESCRIPTION
### Follow-Up Functionality Updates covered in this PR

### REQUIREMENT:
- This is how sales order Should look like for follow-up, in this selected software maintenance
_start date : 23-04-2024
end date: 22-04-2025_

- **_follow-up_** sales-order dates
**_start date: 01-06-2024
end date: 31-05-2025_**
![recording4](https://github.com/SimpaTec/simpatec/assets/14124603/06f50446-2954-45c3-a0b9-394000f4941e)

- In this software maintenance after submitting follow-up, this is what looks like.
in this selected software maintenance
_start date : 23-04-2024
end date: 22-04-2025_

 - follow-up line items dates which is coming from sales order which is type follow-up
start date: _**01-06-2025**_
end date: **_22-04-2026_**

**Note: the end dates becomes same as previous items.**

<img width="1289" alt="Screenshot 2024-04-26 at 14 57 25" src="https://github.com/SimpaTec/simpatec/assets/14124603/07f3289e-44e3-49e9-bd31-7b91e90067f4">



### RESULT
![recording-follow-up](https://github.com/SimpaTec/simpatec/assets/14124603/2bcbcd4c-725f-4547-a8fa-c80e3d4f18d1)

