### PR TITLE
Added Reoccuring amount field

### DIFF
--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -2,7 +2,6 @@
  "actions": [],
  "autoname": "hash",
  "creation": "2023-12-12 15:46:05.617258",
- "default_view": "List",
  "doctype": "DocType",
  "document_type": "Document",
  "editable_grid": 1,
@@ -19,6 +18,7 @@
   "qty",
   "uom",
   "conversion_factor",
+  "reoccuring_maintenance_amount",
   "rate",
   "price_list_rate"
  ],
@@ -140,19 +140,22 @@
    "label": "Item Language",
    "options": "Language",
    "reqd": 1
+  },
+  {
+   "fieldname": "reoccuring_maintenance_amount",
+   "fieldtype": "Currency",
+   "label": "Reoccuring Maintenance Amount"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-01-11 10:12:18.794450",
+ "modified": "2024-04-30 12:17:35.276133",
  "modified_by": "Administrator",
- "module": "SimpaTec",
+ "module": "Simpatec",
  "name": "Software Maintenance Item",
- "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
1. Added Reoccuring Amount field in Software Maintenance Item Level
2. Sales Order Reoccuring Amount is going to software maintenance item level on First / Follow-up Sales after submission

<img width="1242" alt="Screenshot 2024-04-30 at 15 47 38" src="https://github.com/SimpaTec/simpatec/assets/14124603/d1103886-c9b7-43c6-b584-43f27e8e80f6">
<img width="1248" alt="Screenshot 2024-04-30 at 15 49 54" src="https://github.com/SimpaTec/simpatec/assets/14124603/68de29c6-33b4-4e6e-be5b-af2ffb4503db">

Note: Migration Needed.