### PR TITLE
Reoccuring Amount Calculation Modification

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -4,6 +4,7 @@ from frappe import _
 from frappe.utils import cint, cstr, flt, add_days, add_years, today, getdate
 from frappe.model.mapper import get_mapped_doc
 from datetime import date, timedelta, datetime
+from dateutil import relativedelta
 
 
 @frappe.whitelist()
@@ -125,15 +126,12 @@ def update_software_maintenance(doc, method=None):
 			item_end_date = item_end_date + timedelta(days=365)
 			if doc.sales_order_type == "Follow-Up Sale":
 				item_end_date = software_maintenance.performance_period_end + timedelta(days=365)
-				per_day_rate = item_rate / 365
+				per_month_rate = flt(item_rate / 12,2)
 				start_date = item_start_date
-				d0 = start_date
-				d1 = item_end_date
-				delta = d1 - d0
-				days_remaining = delta.days
-				total_remaining_item_rate = days_remaining * per_day_rate
+				delta_months = relativedelta.relativedelta(item_end_date, start_date)
+				remaining_months = delta_months.months
+				total_remaining_item_rate = remaining_months * per_month_rate
 				item_rate = total_remaining_item_rate
-			# expected_end_date = item.end_date + timedelta(days=365)
 
 			days_diff = item_end_date - item_start_date
 			if days_diff == 365:


### PR DESCRIPTION
IN this PR we have modified the calculation of reoccuring amount to month wise
### Previous Behaviour
- While Submitting the follow-up sales order system was calculating the reoccuring amount on days. 
     - Formula : 
     -     days difference = (Start/end) date
     -     per day reoccuring amount = reoccuring amount / 365
     -     difference reoccuring amount  = (per day reoccuring amount ) * (days difference) 
- Result 
- <img width="1350" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/11742166-9f24-4c88-9546-4e6d363db6be">


### Requirement:
- Change the calculation from days to months for reoccuring maintenance amount
     - Formula : 
     -     months difference = (Start/end) date
     -     per month reoccuring amount = reoccuring amount / 12
     -     difference reoccuring amount  = (per month reoccuring amount ) * (months difference) 
 - Result 
- <img width="1333" alt="Screenshot 2024-04-30 at 16 29 24" src="https://github.com/SimpaTec/simpatec/assets/14124603/c3c385ef-3e9e-481f-abfd-6f11ba283197">
