### PR TITLE
Software Maintenance Reoccuring Workflow

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -113,6 +113,11 @@ def update_software_maintenance(doc, method=None):
 			item_reoccuring_maintenance_amount = item.reoccuring_maintenance_amount
 			item_start_date = item.start_date
 			item_end_date = item.end_date
+
+			if doc.sales_order_type == "Reoccuring Maintenance":
+				item_start_date = software_maintenance.performance_period_start
+				item_end_date = software_maintenance.performance_period_end
+
 			if item.item_type == "Maintenance Item":
 				item_rate = item.reoccuring_maintenance_amount
 			else:

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
@@ -18,16 +18,15 @@ frappe.ui.form.on('Software Maintenance', {
 
         frm.add_custom_button('Reoccuring Software Maintenance', function () {
             frappe.call({
-                method: "simpatec.simpatec.doctype.software_maintenance.software_maintenance.make_sales_order",
+                method: "simpatec.simpatec.doctype.software_maintenance.software_maintenance.make_reoccuring_sales_order",
                 args: {
                     software_maintenance: frm.doc.name,
-                    is_background_job: 0,
-                    is_reoccuring: 1
+                    is_background_job: 0
                 },
                 callback: function (r) {
                 },
             });
-        }, __("Create Sales Order"));
+        });
 
 
         //hide all + in the connection

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -28,7 +28,7 @@ class SoftwareMaintenance(Document):
 
 
 @frappe.whitelist()
-def make_sales_order(software_maintenance, is_background_job=True, is_reoccuring=None):
+def make_reoccuring_sales_order(software_maintenance, is_background_job=True):
 	software_maintenance = frappe.get_doc("Software Maintenance", software_maintenance)
 	if not software_maintenance.assign_to:
 		frappe.throw(_("Please set 'Assign to' in Software maintenance '{0}'").format(software_maintenance.name))
@@ -60,17 +60,17 @@ def make_sales_order(software_maintenance, is_background_job=True, is_reoccuring
 	sales_order.order_type = "Sales"
 
 	for item in software_maintenance.items:
-		start_date = performance_period_start
-		item_rate = item.rate
-		if item.start_date != old_start_date:
-			per_day_rate = item.rate / 365
-			start_date = item.end_date
-			d0 = start_date
-			d1 = performance_period_end
-			delta = d1 - d0
-			days_remaining = delta.days
-			total_remaining_item_rate = days_remaining * per_day_rate
-			item_rate = total_remaining_item_rate
+		# start_date = performance_period_start
+		# item_rate = item.rate
+		# if item.start_date != old_start_date:
+		# 	per_day_rate = item.rate / 365
+		# 	start_date = item.end_date
+		# 	d0 = start_date
+		# 	d1 = performance_period_end
+		# 	delta = d1 - d0
+		# 	days_remaining = delta.days
+		# 	total_remaining_item_rate = days_remaining * per_day_rate
+		# 	item_rate = total_remaining_item_rate
 
 		sales_order.append("items", {
 			"item_code": item.item_code,
@@ -78,13 +78,13 @@ def make_sales_order(software_maintenance, is_background_job=True, is_reoccuring
 			"description": item.description,
 			"conversion_factor": item.conversion_factor,
 			"qty": item.qty,
-			"rate": item_rate,
-			"reoccuring_maintenance_amount": item_rate,
+			"rate": item.rate,
+			"reoccuring_maintenance_amount": item.reoccuring_maintenance_amount,
 			"uom": item.uom,
 			"item_language": item.item_language,
 			"delivery_date": sales_order.transaction_date,
-			"start_date": start_date,
-			"end_date": performance_period_end
+			"start_date": item.start_date,
+			"end_date": item.end_date
 		})
 
 	sales_order.insert()


### PR DESCRIPTION
Software Reoccuring Maintenance Updates Covered in this PR
- Added Button for Create Reoccuring Maintenance
- <img width="1060" alt="Screenshot 2024-05-02 at 11 57 57" src="https://github.com/SimpaTec/simpatec/assets/14124603/b2237bcc-bf8c-4603-a599-21e9ccfc15b8">
- Sales Order Type will set to Reoccuring Maintenance
- <img width="1157" alt="Screenshot 2024-05-02 at 12 03 38 copy" src="https://github.com/SimpaTec/simpatec/assets/14124603/e850a2a1-0f1a-47ca-a2a7-22a87108bfaa">
- Software Maintenance start/end date will copy into Sales Order with +1 Year
- <img width="1157" alt="Screenshot 2024-05-02 at 12 03 38" src="https://github.com/SimpaTec/simpatec/assets/14124603/aa74a4aa-7c07-418a-b39f-1b72e3b7f349">
- Software Maintenance Item Level Values copied into Sales Order 
- <img width="1087" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/3d5a7ded-9845-41a8-a9cb-0a6a089a546e">
- Overall look of sales order
- <img width="1317" alt="Screenshot 2024-05-02 at 11 49 22" src="https://github.com/SimpaTec/simpatec/assets/14124603/29b2165e-b6d5-4e41-947f-7657c7a164fe">
- After Submitting Sales Order, Software Maintenance Doclevel Start/end dates will reflect will same dates
- <img width="1057" alt="Screenshot 2024-05-02 at 11 46 42" src="https://github.com/SimpaTec/simpatec/assets/14124603/01e6a85c-0044-4f43-a93d-a89a4c07d964">
- Items appended in software maintenance table same as sales order, with +1 year from doclevel software maintenance
- <img width="1145" alt="Screenshot 2024-05-02 at 11 42 37" src="https://github.com/SimpaTec/simpatec/assets/14124603/6ad61306-b493-4ad4-a1a6-60c611f746d5">



