### PR TITLE
Added einkaufspreis field in SO/Software Maintenance Items

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -167,7 +167,8 @@ def update_software_maintenance(doc, method=None):
 				"rate": item_rate,
 				"reoccuring_maintenance_amount": item_reoccuring_maintenance_amount,
 				"qty": item.qty,
-				"uom": item.uom
+				"uom": item.uom,
+				"einkaufspreis": item.einkaufspreis
 			})
 
 		software_maintenance.save()

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -390,6 +390,19 @@ def get_custom_fields():
 			"depends_on": "eval:doc.item_language == 'fr'",
 			"insert_after": "id_de",
 		},
+		{
+			"label": "Einkauf",
+			"fieldname": "einkauf",
+			"insert_after": "transaction_date",
+			"fieldtype": "Section Break",
+		},
+		{
+			"label": "Einkaufspreis",
+			"fieldname": "einkaufspreis",
+			"insert_after": "einkauf",
+			"fieldtype": "Currency",
+			"allow_on_submit": 1,
+		}
 	]
 
 	custom_fields_item = [

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -60,18 +60,6 @@ def make_reoccuring_sales_order(software_maintenance, is_background_job=True):
 	sales_order.order_type = "Sales"
 
 	for item in software_maintenance.items:
-		# start_date = performance_period_start
-		# item_rate = item.rate
-		# if item.start_date != old_start_date:
-		# 	per_day_rate = item.rate / 365
-		# 	start_date = item.end_date
-		# 	d0 = start_date
-		# 	d1 = performance_period_end
-		# 	delta = d1 - d0
-		# 	days_remaining = delta.days
-		# 	total_remaining_item_rate = days_remaining * per_day_rate
-		# 	item_rate = total_remaining_item_rate
-
 		sales_order.append("items", {
 			"item_code": item.item_code,
 			"item_name": item.item_name,
@@ -84,7 +72,8 @@ def make_reoccuring_sales_order(software_maintenance, is_background_job=True):
 			"item_language": item.item_language,
 			"delivery_date": sales_order.transaction_date,
 			"start_date": item.start_date,
-			"end_date": item.end_date
+			"end_date": item.end_date,
+			"einkaufspreis": item.einkaufspreis
 		})
 
 	sales_order.insert()

--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -20,7 +20,9 @@
   "conversion_factor",
   "reoccuring_maintenance_amount",
   "rate",
-  "price_list_rate"
+  "price_list_rate",
+  "einkauf_section",
+  "einkaufspreis"
  ],
  "fields": [
   {
@@ -149,11 +151,22 @@
    "fieldname": "reoccuring_maintenance_amount",
    "fieldtype": "Currency",
    "label": "Reoccuring Maintenance Amount"
+  },
+  {
+   "fieldname": "einkauf_section",
+   "fieldtype": "Section Break",
+   "label": "Einkauf"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "einkaufspreis",
+   "fieldtype": "Currency",
+   "label": "Einkaufspreis"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-05-02 14:23:13.603984",
+ "modified": "2024-05-06 13:07:30.985487",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Software Maintenance Item",


### PR DESCRIPTION
### **Note: Migration Needed**

In this PR i have added **_einkaufspreis_** field in Sales Order Items and Software Maintenance Items

Added **_einkaufspreis_** in Items
- Sales Order Item
- <img width="1306" alt="Screenshot 2024-05-06 at 16 00 15" src="https://github.com/SimpaTec/simpatec/assets/14124603/f7367272-c467-426f-ac00-e887086baa40">

- Software Maintenance Item
- <img width="1318" alt="Screenshot 2024-05-06 at 15 59 13" src="https://github.com/SimpaTec/simpatec/assets/14124603/aec81326-fbb1-4ae4-9e81-3ab2b2ffec39">

- **_einkaufspreis_** field value reflecting after Sales Order Submitting, Or Making Reoccuring Sales Order from Software Maintenance.
![recording-einkaufspreis_field](https://github.com/SimpaTec/simpatec/assets/14124603/52974c4e-ccea-4711-aef7-f51a70aab2c1)


