### PR TITLE
Auto Required Date and Remove Item Description 

### DIFF
--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -365,7 +365,7 @@ def get_custom_fields():
 
 		{
 			"label": "Item Description EN",
-			"fieldname": "id_de",
+			"fieldname": "id_en",
 			"fieldtype": "Text Editor",
 			"fetch_from": "item_code.id_en",
 			"fetch_if_empty": 1,
@@ -379,11 +379,11 @@ def get_custom_fields():
 			"fetch_from": "item_code.id_de",
 			"fetch_if_empty": 1,
 			"depends_on": "eval:doc.item_language == 'de'",
-			"insert_after": "id_de",
+			"insert_after": "id_en",
 		},
 		{
 			"label": "Item Description FR",
-			"fieldname": "id_de",
+			"fieldname": "id_fr",
 			"fieldtype": "Text Editor",
 			"fetch_from": "item_code.in_fr",
 			"fetch_if_empty": 1,
@@ -480,6 +480,70 @@ def get_custom_fields():
 		},
 	]
 
+	custom_fields_poi = [
+		{
+			"label": "Item Language",
+			"fieldname": "item_language",
+			"fieldtype": "Link",
+			"options": "Language",
+			"insert_after": "column_break_4",
+		},
+		{
+			"label": "Item Name EN",
+			"fieldname": "item_name_en",
+			"fieldtype": "Data",
+			"fetch_from": "item_code.in_en",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'en'",
+			"insert_after": "item_name",
+		},
+		{
+			"label": "Item Name DE",
+			"fieldname": "item_name_de",
+			"fieldtype": "Data",
+			"fetch_from": "item_code.in_de",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'de'",
+			"insert_after": "item_name_en",
+		},
+		{
+			"label": "Item Name FR",
+			"fieldname": "item_name_fr",
+			"fieldtype": "Data",
+			"fetch_from": "item_code.in_fr",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'fr'",
+			"insert_after": "item_name_de",
+		},
+		{
+			"label": "Item Description EN",
+			"fieldname": "item_description_en",
+			"fieldtype": "Text Editor",
+			"fetch_from": "item_code.id_en",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'en'",
+			"insert_after": "description",
+		},
+		{
+			"label": "Item Description DE",
+			"fieldname": "item_description_de",
+			"fieldtype": "Text Editor",
+			"fetch_from": "item_code.id_de",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'de'",
+			"insert_after": "item_description_en",
+		},
+		{
+			"label": "Item Description FR",
+			"fieldname": "item_description_fr",
+			"fieldtype": "Text Editor",
+			"fetch_from": "item_code.in_fr",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'fr'",
+			"insert_after": "item_description_de",
+		},
+	]
+
 
 	return {
 		"Customer": custom_fields_customer,
@@ -489,4 +553,5 @@ def get_custom_fields():
 		"Sales Invoice": custom_fields_si,
 		"Purchase Invoice": custom_fields_pi,
 		"Purchase Order": custom_fields_po,
+		"Purchase Order Item": custom_fields_poi,
 	}

--- a/simpatec/public/js/purchase_order.js
+++ b/simpatec/public/js/purchase_order.js
@@ -1,5 +1,38 @@
 frappe.ui.form.on('Purchase Order', {
-	
+	refresh: function(frm){
+		let btn = cur_frm.fields_dict.items.grid.add_custom_button("Remove Item Description", function(){ 
+			if (!is_null(frm.fields_dict.items.grid.get_selected_children())) {
+				$.each(frm.fields_dict.items.grid.get_selected_children(), (k, v) => {
+					v.description = ""
+					if (v.item_language == 'en'){
+						v.item_description_en = ""
+					} else if(v.item_language == 'de'){
+						v.item_description_de = ""
+					} else if (v.item_language == 'fr') {
+						v.item_description_fr = ""
+					}
+					v.__checked = 0
+				})
+			}else{
+				$.each(frm.doc.items, (k, v) => {
+					v.description = ""
+					if (v.item_language == 'en') {
+						v.item_description_en = ""
+					} else if (v.item_language == 'de') {
+						v.item_description_de = ""
+					} else if (v.item_language == 'fr') {
+						v.item_description_fr = ""
+					}
+					v.__checked = 0
+				})
+			}
+			refresh_field("items");
+			frm.dirty()
+			frappe.msgprint("Item Description Removed")
+		})
+		btn.addClass("btn-secondary")
+		btn.removeClass("btn-default")
+	},
 	setup: function(frm){
 		frm.copy_from_previous_row = function(parentfield, current_row, fieldnames){
 			

--- a/simpatec/public/js/purchase_order.js
+++ b/simpatec/public/js/purchase_order.js
@@ -93,7 +93,9 @@ frappe.ui.form.on('Purchase Order Item',{
 	},
 
 	schedule_date: function(frm, cdt, cdn){
+		let cur_row = locals[cdt][cdn]
 		frm.auto_fill_all_empty_rows(frm.doc, cdt, cdn, "items", "schedule_date");
+		frm.set_value("schedule_date", cur_row.schedule_date)
 	}
 	
 });

--- a/simpatec/public/js/purchase_order.js
+++ b/simpatec/public/js/purchase_order.js
@@ -89,9 +89,11 @@ frappe.ui.form.on('Purchase Order Item',{
 					}
 				)
 			}
-		}
-		
-		
+		}	
 	},
+
+	schedule_date: function(frm, cdt, cdn){
+		frm.auto_fill_all_empty_rows(frm.doc, cdt, cdn, "items", "schedule_date");
+	}
 	
 });


### PR DESCRIPTION
### Issues Covered in this PR
1. Gitlab Issue [#39](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/14?work_item_iid=39)
2. Gitlab Issue [#41](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/41)




### Points for Gitlab Issue [#39](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/14?work_item_iid=39)
- Auto Reflect required date in all item rows when change in any one of the row
![recording-autochangePOdate](https://github.com/SimpaTec/simpatec/assets/14124603/201fdbb7-ff11-4a91-b554-9c1becc491c8)

<br><br>


### Points for Gitlab Issue [#41](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/41)
- Added item description fields for purchase order items in custom app 
- Added Remove Description Button in PO Item table
- Description will be remove for specific rows if selected
- <img width="1325" alt="Screenshot 2024-05-07 at 01 08 41" src="https://github.com/SimpaTec/simpatec/assets/14124603/1d502122-e2e3-4cc9-ab22-6c87a7f31fb1">

- Description will be remove for all items rows if not selected specific rows
- <img width="1512" alt="Screenshot 2024-05-07 at 01 13 06" src="https://github.com/SimpaTec/simpatec/assets/14124603/abe90874-4cd2-4356-86e3-cf493559b597">
- Preview
- ![recording-remove_description](https://github.com/SimpaTec/simpatec/assets/14124603/45e936ad-92c1-429f-83bf-944bcbc93b6f)
