### PR TITLE
Update software maintenance Items 

### DIFF
--- a/simpatec/patches/v13_0/fixture_set_sales_order_items.py
+++ b/simpatec/patches/v13_0/fixture_set_sales_order_items.py
@@ -1,50 +1,57 @@
 import frappe
 from datetime import timedelta
 
-# @frappe.whitelist()
+@frappe.whitelist()
 def execute():
-    """Query for removing all previous Software maintenance Items"""
-    frappe.db.sql("DELETE FROM `tabSoftware Maintenance Item`")
-    frappe.db.commit()
-    software_maintenances = frappe.get_all("Software Maintenance", fields=["sales_order", "name"], filters=[["sales_order","is","set"]])
-    for s_m in software_maintenances:
-        so_items = frappe.get_all("Sales Order Item", filters={"parent": s_m.sales_order}, fields=["*"])
-        if len(so_items) > 0:
-            for item in so_items:   
-                software_maintenance_items = frappe.new_doc("Software Maintenance Item")
+    try:
+        """Query for removing all previous Software maintenance Items"""
+        frappe.db.sql("DELETE FROM `tabSoftware Maintenance Item`")
+        frappe.db.commit()
+        software_maintenances = frappe.get_all("Software Maintenance", fields=["sales_order", "name"], filters=[["sales_order","is","set"]])
+        for s_m in software_maintenances:
+            so_items = frappe.get_all("Sales Order Item", filters={"parent": s_m.sales_order}, fields=["*"])
+            if len(so_items) > 0:
+                for item in so_items:   
+                    software_maintenance_items = frappe.new_doc("Software Maintenance Item")
 
-                item.start_date = item.start_date + timedelta(days=365)
-                item.end_date = item.end_date + timedelta(days=365)
-                days_diff = item.end_date - item.start_date
-                if days_diff == 365:
-                    item.end_date = item.end_date - timedelta(days=1)
-                # if item.item_type == "Maintenance Item":
-                #     item.rate = item.reoccuring_maintenance_amount
-                #     item.reoccuring_maintenance_amount = item.reoccuring_maintenance_amount
-                # else:
-                #     item.rate = 0
-                #     item.reoccuring_maintenance_amount = 0
+                    item.start_date = item.start_date + timedelta(days=365)
+                    item.end_date = item.end_date + timedelta(days=365)
+                    days_diff = item.end_date - item.start_date
+                    if days_diff == 365:
+                        item.end_date = item.end_date - timedelta(days=1)
+                    # if item.item_type == "Maintenance Item":
+                    #     item.rate = item.reoccuring_maintenance_amount
+                    #     item.reoccuring_maintenance_amount = item.reoccuring_maintenance_amount
+                    # else:
+                    #     item.rate = 0
+                    #     item.reoccuring_maintenance_amount = 0
 
-
-                software_maintenance_items.update({
-                    "idx": item.idx,
-                    "item_code": item.item_code,
-                    "item_name": item.item_name,
-                    "description": item.description,
-                    "conversion_factor": item.conversion_factor,
-                    "qty": item.qty,
-                    "rate": item.rate,
-                    # "reoccuring_maintenance_amount": item.reoccuring_maintenance_amount,
-                    "uom": item.uom,
-                    "item_language": item.item_language,
-                    "delivery_date": frappe.db.get_value("Sales Order", s_m.sales_order, "transaction_date"),
-                    "start_date": item.start_date,
-                    "end_date": item.end_date,
-                    # "einkaufspreis": item.einkaufspreis,
-                    'parent': s_m.name,
-                    'parentfield': 'items',
-                    'parenttype': "Software Maintenance"
-                })
-                software_maintenance_items.insert(ignore_permissions=True)
-            frappe.db.set_value("Software Maintenance", s_m.name, "assign_to", frappe.db.get_value("Sales Order", s_m.sales_order, "assigned_to"), update_modified=False)
-            frappe.db.set_value("Sales Order", s_m.sales_order, "sales_order_type", "First Sale", update_modified=False)
+                    software_maintenance_items.update({
+                        "idx": item.idx,
+                        "item_code": item.item_code,
+                        "item_name": item.item_name,
+                        "description": item.description,
+                        "conversion_factor": item.conversion_factor,
+                        "qty": item.qty,
+                        "rate": item.rate,
+                        # "reoccuring_maintenance_amount": item.reoccuring_maintenance_amount,
+                        "uom": item.uom,
+                        "item_language": item.item_language,
+                        "delivery_date": frappe.db.get_value("Sales Order", s_m.sales_order, "transaction_date"),
+                        "start_date": item.start_date,
+                        "end_date": item.end_date,
+                        # "einkaufspreis": item.einkaufspreis,
+                        'parent': s_m.name,
+                        'parentfield': 'items',
+                        'parenttype': "Software Maintenance"
+                    })
+                    software_maintenance_items.insert(ignore_permissions=True)
+                frappe.db.set_value("Software Maintenance", s_m.name, "assign_to", frappe.db.get_value("Sales Order", s_m.sales_order, "assigned_to"), update_modified=False)
+                frappe.db.set_value("Sales Order", s_m.sales_order, "sales_order_type", "First Sale", update_modified=False)
+                frappe.db.sql("""update `tabSales Order` set `sales_order_type` = 'Reoccuring Maintenance' where `sales_order_type` = 'Follow Up Maintenance' """)
+                frappe.db.commit()
+        return "Process Completed Successfully. All Items in Software Maintenance Has been updated"        
+    except Exception as ex:
+        frappe.db.rollback()
+        frappe.log_error(ex)
+        return "There was some error occured in the process, Please check error logs."

--- a/simpatec/patches/v13_0/fixture_set_sales_order_items.py
+++ b/simpatec/patches/v13_0/fixture_set_sales_order_items.py
@@ -1,0 +1,50 @@
+import frappe
+from datetime import timedelta
+
+# @frappe.whitelist()
+def execute():
+    """Query for removing all previous Software maintenance Items"""
+    frappe.db.sql("DELETE FROM `tabSoftware Maintenance Item`")
+    frappe.db.commit()
+    software_maintenances = frappe.get_all("Software Maintenance", fields=["sales_order", "name"], filters=[["sales_order","is","set"]])
+    for s_m in software_maintenances:
+        so_items = frappe.get_all("Sales Order Item", filters={"parent": s_m.sales_order}, fields=["*"])
+        if len(so_items) > 0:
+            for item in so_items:   
+                software_maintenance_items = frappe.new_doc("Software Maintenance Item")
+
+                item.start_date = item.start_date + timedelta(days=365)
+                item.end_date = item.end_date + timedelta(days=365)
+                days_diff = item.end_date - item.start_date
+                if days_diff == 365:
+                    item.end_date = item.end_date - timedelta(days=1)
+                # if item.item_type == "Maintenance Item":
+                #     item.rate = item.reoccuring_maintenance_amount
+                #     item.reoccuring_maintenance_amount = item.reoccuring_maintenance_amount
+                # else:
+                #     item.rate = 0
+                #     item.reoccuring_maintenance_amount = 0
+
+
+                software_maintenance_items.update({
+                    "idx": item.idx,
+                    "item_code": item.item_code,
+                    "item_name": item.item_name,
+                    "description": item.description,
+                    "conversion_factor": item.conversion_factor,
+                    "qty": item.qty,
+                    "rate": item.rate,
+                    # "reoccuring_maintenance_amount": item.reoccuring_maintenance_amount,
+                    "uom": item.uom,
+                    "item_language": item.item_language,
+                    "delivery_date": frappe.db.get_value("Sales Order", s_m.sales_order, "transaction_date"),
+                    "start_date": item.start_date,
+                    "end_date": item.end_date,
+                    # "einkaufspreis": item.einkaufspreis,
+                    'parent': s_m.name,
+                    'parentfield': 'items',
+                    'parenttype': "Software Maintenance"
+                })
+                software_maintenance_items.insert(ignore_permissions=True)
+            frappe.db.set_value("Software Maintenance", s_m.name, "assign_to", frappe.db.get_value("Sales Order", s_m.sales_order, "assigned_to"), update_modified=False)
+            frappe.db.set_value("Sales Order", s_m.sales_order, "sales_order_type", "First Sale", update_modified=False)

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.js
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.js
@@ -2,7 +2,16 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('SimpaTec Settings', {
-	// refresh: function(frm) {
-
-	// }
+	refresh: function(frm) {
+		frm.add_custom_button("Update Software Maintenance Items", function(){
+			frm.call({
+				method: "simpatec.patches.v13_0.fixture_set_sales_order_items.execute",
+				callback: function (r) {
+					if(r.message){
+						frappe.msgprint(r.message)
+					}
+				}
+			})
+		})
+	}
 });


### PR DESCRIPTION
### [Gitlab Issue 46](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/26?work_item_iid=46)
### Points covered in this PR

- Made an script that will perform the functions mentioned below
      1. Added a Custom button to trigger the script
        <img width="1330" alt="Screenshot 2024-05-22 at 12 45 25" src="https://github.com/SimpaTec/simpatec/assets/14124603/11a55e68-dd81-4734-b2cf-87911830b737">
      2. Clear Item from All Software Maintenance
      3. Relink items from sales order which is already selected in software maintenance doclevel
         <img width="765" alt="Screenshot 2024-05-22 at 12 39 09" src="https://github.com/SimpaTec/simpatec/assets/14124603/5dd98d7b-f1a1-4b8f-9be9-f902b4a49c9a">
      4. Set the linked sales order as **First Sales** in **_Sales order_**
        <img width="1493" alt="Screenshot 2024-05-22 at 12 41 40" src="https://github.com/SimpaTec/simpatec/assets/14124603/4a570e9f-c421-475e-9ecc-c35f9a59e84f">
      5. Update All Sales order type from 'Follow-up Maintenance' to 'Reoccuring Maintenance' 
        <img width="1466" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/b2595829-ff41-4168-825e-5cfd120a2558">


- Full Process of the script
![recording-update_sm_items](https://github.com/SimpaTec/simpatec/assets/14124603/fb262c22-7534-4deb-9cba-fd73c71b026e)




