### PR TITLE
Removed wrong Reoccurring maintenance Field, added new one with correct fieldname

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -62,11 +62,11 @@ def make_software_maintenance(source_name, target_doc=None):
 					item.end_date = item.end_date - timedelta(days=1)
 				so_item = source.items[item.idx-1]
 				if so_item.item_type == "Maintenance Item":
-					item.rate = so_item.reoccuring_maintenance_amount
-					item.reoccuring_maintenance_amount = so_item.reoccuring_maintenance_amount
+					item.rate = so_item.reoccurring_maintenance_amount
+					item.reoccurring_maintenance_amount = so_item.reoccurring_maintenance_amount
 				else:
 					item.rate = 0
-					item.reoccuring_maintenance_amount = 0
+					item.reoccurring_maintenance_amount = 0
 		doc.assign_to = source.assigned_to
 
 	doc = get_mapped_doc(
@@ -110,7 +110,7 @@ def update_software_maintenance(doc, method=None):
 		software_maintenance.sale_order = doc.name
 		for item in doc.items:
 			item_rate = item.rate
-			item_reoccuring_maintenance_amount = item.reoccuring_maintenance_amount
+			item_reoccurring_maintenance_amount = item.reoccurring_maintenance_amount
 			item_start_date = item.start_date
 			item_end_date = item.end_date
 
@@ -119,7 +119,7 @@ def update_software_maintenance(doc, method=None):
 				item_end_date = software_maintenance.performance_period_end
 
 			if item.item_type == "Maintenance Item":
-				item_rate = item.reoccuring_maintenance_amount
+				item_rate = item.reoccurring_maintenance_amount
 			else:
 				item_rate = 0
 				item_reoccuring_maintenance_amount = 0
@@ -165,7 +165,7 @@ def update_software_maintenance(doc, method=None):
 				"conversion_factor": item.conversion_factor,
 				"item_language": item.item_language,
 				"rate": item_rate,
-				"reoccuring_maintenance_amount": item_reoccuring_maintenance_amount,
+				"reoccurring_maintenance_amount": item_reoccurring_maintenance_amount,
 				"qty": item.qty,
 				"uom": item.uom,
 				"einkaufspreis": item.einkaufspreis

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -304,8 +304,8 @@ def get_custom_fields():
 			"insert_after": "item_type",
 		},
 		{
-			"label": "Reoccuring Maintenance Amount",
-			"fieldname": "reoccuring_maintenance_amount",
+			"label": "Reoccurring Maintenance Amount",
+			"fieldname": "reoccurring_maintenance_amount",
 			"fieldtype": "Currency",
 			"description": "The grand total of the reoccurring maintenance cost",
 			"depends_on": "eval: doc.item_type == \"Maintenance Item\"",
@@ -314,7 +314,7 @@ def get_custom_fields():
 		{
 			"fieldname": "section_break_kiny4",
 			"fieldtype": "Section Break",
-			"insert_after": "reoccuring_maintenance_amount"
+			"insert_after": "reoccurring_maintenance_amount"
 		},
 		{
 			"label": "Item Language",

--- a/simpatec/patches.txt
+++ b/simpatec/patches.txt
@@ -1,1 +1,2 @@
 simpatec.patches.v13_0.fixture_for_contact_set_contacts_link_title #fix 20240406
+simpatec.patches.v13_0.remove_wrong_reoccuring_maintenance_amount_field #fix 20240523

--- a/simpatec/patches/v13_0/fixture_set_sales_order_items.py
+++ b/simpatec/patches/v13_0/fixture_set_sales_order_items.py
@@ -22,12 +22,12 @@ def execute():
                             days_diff = item.end_date - item.start_date
                             if days_diff == 365:
                                 item.end_date = item.end_date - timedelta(days=1)
-                    # if item.item_type == "Maintenance Item":
-                    #     item.rate = item.reoccuring_maintenance_amount
-                    #     item.reoccuring_maintenance_amount = item.reoccuring_maintenance_amount
-                    # else:
-                    #     item.rate = 0
-                    #     item.reoccuring_maintenance_amount = 0
+                    if item.item_type == "Maintenance Item":
+                        item.rate = item.reoccurring_maintenance_amount
+                        item.reoccurring_maintenance_amount = item.reoccurring_maintenance_amount
+                    else:
+                        item.rate = 0
+                        item.reoccurring_maintenance_amount = 0
 
                     software_maintenance_items.update({
                         "idx": item.idx,
@@ -36,8 +36,8 @@ def execute():
                         "description": item.description,
                         "conversion_factor": item.conversion_factor,
                         "qty": item.qty,
-                        "rate": item.reoccuring_maintenance_amount,
-                        "reoccuring_maintenance_amount": item.reoccuring_maintenance_amount,
+                        "rate": item.reoccurring_maintenance_amount,
+                        "reoccurring_maintenance_amount": item.reoccurring_maintenance_amount,
                         "uom": item.uom,
                         "item_language": item.item_language,
                         "delivery_date": frappe.db.get_value("Sales Order", s_m.sales_order, "transaction_date"),
@@ -53,6 +53,7 @@ def execute():
                 # frappe.db.set_value("Software Maintenance", s_m.name, "assign_to", frappe.db.get_value("Sales Order", s_m.sales_order, "assigned_to"), update_modified=False)
                 frappe.db.sql("""update `tabSoftware Maintenance` set `modified` = '{modified}', `modified_by` = '{modified_by}' where `name` = '{sm_name}'""".format(modified= now(), modified_by= modified_by, sm_name=s_m.name))
                 frappe.db.set_value("Sales Order", s_m.sales_order, "sales_order_type", "First Sale")
+                frappe.db.set_value("Sales Order", s_m.sales_order, "software_maintenance", s_m.name)
                 frappe.db.sql("""update `tabSales Order` set `sales_order_type` = 'Reoccuring Maintenance', `modified` = '{modified}', `modified_by` = '{modified_by}' where `sales_order_type` = 'Follow Up Maintenance' """.format(modified= now(), modified_by= modified_by))
                 frappe.db.commit()
         return {"message":"""<h3>The script has run and had updated all Software Maintenance:</h3>

--- a/simpatec/patches/v13_0/remove_wrong_reoccuring_maintenance_amount_field.py
+++ b/simpatec/patches/v13_0/remove_wrong_reoccuring_maintenance_amount_field.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+    if frappe.db.exists("Custom Field", "Sales Order Item-reoccuring_maintenance_amount"):
+        frappe.delete_doc("Custom Field", "Sales Order Item-reoccuring_maintenance_amount", force=1)

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -67,7 +67,7 @@ def make_reoccuring_sales_order(software_maintenance, is_background_job=True):
 			"conversion_factor": item.conversion_factor,
 			"qty": item.qty,
 			"rate": item.rate,
-			"reoccuring_maintenance_amount": item.reoccuring_maintenance_amount,
+			"reoccurring_maintenance_amount": item.reoccurring_maintenance_amount,
 			"uom": item.uom,
 			"item_language": item.item_language,
 			"delivery_date": sales_order.transaction_date,

--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -18,7 +18,7 @@
   "qty",
   "uom",
   "conversion_factor",
-  "reoccuring_maintenance_amount",
+  "reoccurring_maintenance_amount",
   "rate",
   "price_list_rate",
   "einkauf_section",
@@ -148,11 +148,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "reoccuring_maintenance_amount",
-   "fieldtype": "Currency",
-   "label": "Reoccuring Maintenance Amount"
-  },
-  {
    "fieldname": "einkauf_section",
    "fieldtype": "Section Break",
    "label": "Einkauf"
@@ -162,11 +157,16 @@
    "fieldname": "einkaufspreis",
    "fieldtype": "Currency",
    "label": "Einkaufspreis"
+  },
+  {
+   "fieldname": "reoccurring_maintenance_amount",
+   "fieldtype": "Currency",
+   "label": "Reoccurring Maintenance Amount"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-05-06 13:07:30.985487",
+ "modified": "2024-05-23 10:13:37.108802",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Software Maintenance Item",


### PR DESCRIPTION
Points covered In this PR 

1. Added a patch that will Remove wrong reoccurring maintenance amount field which has the incorrect field name
2. Added New field with fieldname `reoccurring_maintenance_amount` which will now reflect in all over the system

Note: Migration Needed