### PR TITLE
Update in Script, removed patch, not using anymore

### DIFF
--- a/simpatec/patches.txt
+++ b/simpatec/patches.txt
@@ -1,2 +1,1 @@
 simpatec.patches.v13_0.fixture_for_contact_set_contacts_link_title #fix 20240406
-simpatec.patches.v13_0.remove_wrong_reoccuring_maintenance_amount_field #fix 20240523

--- a/simpatec/patches/v13_0/remove_wrong_reoccuring_maintenance_amount_field.py
+++ b/simpatec/patches/v13_0/remove_wrong_reoccuring_maintenance_amount_field.py
@@ -1,5 +1,0 @@
-import frappe
-
-def execute():
-    if frappe.db.exists("Custom Field", "Sales Order Item-reoccuring_maintenance_amount"):
-        frappe.delete_doc("Custom Field", "Sales Order Item-reoccuring_maintenance_amount", force=1)

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
@@ -13,6 +13,16 @@ class SimpaTecSettings(Document):
 @frappe.whitelist()
 def update_software_maintenance_items(update_timestamp=None):
     try:
+
+        # Remove Wrong field of reccuring_maintenance_amount and reoccuring_maintenance_amount if exist
+        if frappe.db.exists("Custom Field", "Sales Order Item-reoccuring_maintenance_amount"):
+            frappe.delete_doc("Custom Field", "Sales Order Item-reoccuring_maintenance_amount", force=1)
+        if frappe.db.exists("Custom Field", "Sales Order Item-reccuring_maintenance_amount"):
+            # First set the value of wrong `reoccurring_maintenance_amount` field into `reoccurring_maintenance_amount`
+            frappe.db.sql("update `tabSales Order Item` set `reoccurring_maintenance_amount` = `reccuring_maintenance_amount` where item_type = 'Maintenance Item'")
+            # Now removing the field
+            frappe.delete_doc("Custom Field", "Sales Order Item-reccuring_maintenance_amount", force=1)
+        
         update_timestamp = int(update_timestamp)
         """Query for removing all previous Software maintenance Items"""
         frappe.db.sql("DELETE FROM `tabSoftware Maintenance Item`")


### PR DESCRIPTION
1. Removed patch for removing reoccurring maintenance amount typo fields because it is not in use anymore.
2. Update Software Maintenance Item button will now copy value from old reoccurring maintenance amount value and copy it into original one, and then remove the typo fields