### PR TITLE
Remove einkaufspreis field and added purchase_price field and transfered data to new field

### DIFF
--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -391,15 +391,15 @@ def get_custom_fields():
 			"insert_after": "id_de",
 		},
 		{
-			"label": "Einkauf",
-			"fieldname": "einkauf",
+			"label": "Purchase Section",
+			"fieldname": "purchase_section",
 			"insert_after": "transaction_date",
 			"fieldtype": "Section Break",
 		},
-		{
-			"label": "Einkaufspreis",
-			"fieldname": "einkaufspreis",
-			"insert_after": "einkauf",
+  		{
+			"label": "Purchase Price",
+			"fieldname": "purchase_price",
+			"insert_after": "purchase_section",
 			"fieldtype": "Currency",
 			"allow_on_submit": 1,
 		}

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -391,7 +391,7 @@ def get_custom_fields():
 			"insert_after": "id_de",
 		},
 		{
-			"label": "Purchase Section",
+			"label": "Purchase",
 			"fieldname": "purchase_section",
 			"insert_after": "transaction_date",
 			"fieldtype": "Section Break",

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
@@ -7,8 +7,7 @@ from datetime import timedelta
 from frappe.utils import now
 
 class SimpaTecSettings(Document):
-	pass
-
+    pass
 
 @frappe.whitelist()
 def update_software_maintenance_items(update_timestamp=None):
@@ -22,6 +21,12 @@ def update_software_maintenance_items(update_timestamp=None):
             frappe.db.sql("update `tabSales Order Item` set `reoccurring_maintenance_amount` = `reccuring_maintenance_amount` where item_type = 'Maintenance Item'")
             # Now removing the field
             frappe.delete_doc("Custom Field", "Sales Order Item-reccuring_maintenance_amount", force=1)
+        if frappe.db.exists("Custom Field", "Sales Order Item-einkaufspreis"):
+            # first update the field value into new one
+            frappe.db.sql("update `tabSales Order Item` set `purchase_price` = `einkaufspreis` ")
+            # now remove the field and its section
+            frappe.delete_doc("Custom Field", "Sales Order Item-einkauf", force=1) # section
+            frappe.delete_doc("Custom Field", "Sales Order Item-einkaufspreis", force=1) # field
         
         update_timestamp = int(update_timestamp)
         """Query for removing all previous Software maintenance Items"""
@@ -62,7 +67,7 @@ def update_software_maintenance_items(update_timestamp=None):
                         "delivery_date": frappe.db.get_value("Sales Order", s_m.sales_order, "transaction_date"),
                         "start_date": item.start_date,
                         "end_date": item.end_date,
-                        # "einkaufspreis": item.einkaufspreis,
+                        "purchase_price": item.purchase_price,
                         'parent': s_m.name,
                         'parentfield': 'items',
                         'parenttype': "Software Maintenance"

--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -21,8 +21,8 @@
   "reoccurring_maintenance_amount",
   "rate",
   "price_list_rate",
-  "einkauf_section",
-  "einkaufspreis"
+  "purchase_section",
+  "purchase_price"
  ],
  "fields": [
   {
@@ -148,25 +148,25 @@
    "reqd": 1
   },
   {
-   "fieldname": "einkauf_section",
-   "fieldtype": "Section Break",
-   "label": "Einkauf"
-  },
-  {
-   "allow_on_submit": 1,
-   "fieldname": "einkaufspreis",
-   "fieldtype": "Currency",
-   "label": "Einkaufspreis"
-  },
-  {
    "fieldname": "reoccurring_maintenance_amount",
    "fieldtype": "Currency",
    "label": "Reoccurring Maintenance Amount"
+  },
+  {
+   "fieldname": "purchase_section",
+   "fieldtype": "Section Break",
+   "label": "Purchase"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "purchase_price",
+   "fieldtype": "Currency",
+   "label": "Purchase Price"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-05-23 10:13:37.108802",
+ "modified": "2024-05-30 10:10:55.722159",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Software Maintenance Item",


### PR DESCRIPTION
### NOTE: MIGRATION REQUIRED
### Points covered in this PR

- Removed einkaufspreis field in both Sales Order Items and Software Maintenance Items doctypes
- Added New field Purchase Price and Section in both Sales Order Items and Software Maintenance Items doctypes
- Transfers values in in new field from old field
- Above Actions will trigger when we click Update Software Maintenance Items button in Simpatec Settings

- Sales Order Items
- <img width="1211" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/ea717efa-5389-4e58-b25c-05354ae7de2b">

- Software Maintenance Items
- <img width="1347" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/12eddd86-93a4-41b3-b6fa-540ad89f5baf">

