### PR TITLE
Payment term customer subsidiary

### DIFF
--- a/simpatec/fixtures/property_setter.json
+++ b/simpatec/fixtures/property_setter.json
@@ -1,0 +1,53 @@
+[
+ {
+  "default_value": null,
+  "doc_type": "Sales Order",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "payment_terms_template",
+  "modified": "2024-06-14 09:31:47.779066",
+  "name": "Sales Order-payment_terms_template-fetch_from",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "property": "fetch_from",
+  "property_type": "Small Text",
+  "row_name": null,
+  "value": "customer_subsidiary.payment_term"
+ },
+ {
+  "default_value": null,
+  "doc_type": "Quotation",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "payment_terms_template",
+  "modified": "2024-06-14 09:33:51.605604",
+  "name": "Quotation-payment_terms_template-fetch_from",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "property": "fetch_from",
+  "property_type": "Small Text",
+  "row_name": null,
+  "value": "customer_subsidiary.payment_term"
+ },
+ {
+  "default_value": null,
+  "doc_type": "Sales Invoice",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "payment_terms_template",
+  "modified": "2024-06-14 09:46:03.000883",
+  "name": "Sales Invoice-payment_terms_template-fetch_from",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "property": "fetch_from",
+  "property_type": "Small Text",
+  "row_name": null,
+  "value": "customer_subsidiary.payment_term"
+ }
+]

--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -224,4 +224,17 @@ fixtures = [
             ]
         ],
     },
+	{
+		"doctype": "Property Setter",
+		"filters": [
+			[
+				"name",
+    			"in",
+				(
+					"Sales Order-payment_terms_template-fetch_from", "Quotation-payment_terms_template-fetch_from",
+					"Sales Invoice-payment_terms_template-fetch_from"     
+				)
+			]
+		]
+	}
 ]

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -179,11 +179,19 @@ def get_custom_fields():
 			"insert_after": "uid"
 		},
 		{
+			"label": "Payment Term",
+			"fieldname": "payment_term",
+			"fieldtype": "Link",
+			"options": "Payment Term",
+			"fetch_from": "customer_subsidiary.payment_term",
+			"insert_after": "customer_subsidiary"
+		},
+		{
 			"label": "Performance Period End",
 			"fieldname": "performance_period_end",
 			"fieldtype": "Date",
 			"description": "Muss gefüllt werden wenn Wartungspositionen in Auftrag gehen.",
-			"insert_after": "customer_subsidiary",
+			"insert_after": "payment_term",
 		},
 		{
 			"label": "Assigned to",
@@ -477,6 +485,21 @@ def get_custom_fields():
 			"options": "Software Maintenance",
 			"insert_after": "accounting_dimensions_section",
 		},
+  		{
+			"label": "Customer Subsidiary",
+			"fieldname": "customer_subsidiary",
+			"fieldtype": "Link",
+			"options": "Customer Subsidiary",
+			"insert_after": "customer_name",
+		},
+    	{
+			"label": "Payment Term",
+			"fieldname": "payment_term",
+			"fieldtype": "Link",
+			"options": "Payment Term",
+			"fetch_from": "customer_subsidiary.payment_term",
+			"insert_after": "customer_subsidiary"
+		},
 	]
 
 	custom_fields_po = [
@@ -592,6 +615,24 @@ def get_custom_fields():
 
 	]
  
+	custom_fields_quo = [
+		{
+			"label": "Customer Subsidiary",
+			"fieldname": "customer_subsidiary",
+			"fieldtype": "Link",
+			"options": "Customer Subsidiary",
+			"insert_after": "party_name",
+		},
+    	{
+			"label": "Payment Term",
+			"fieldname": "payment_term",
+			"fieldtype": "Link",
+			"options": "Payment Term",
+			"fetch_from": "customer_subsidiary.payment_term",
+			"insert_after": "customer_subsidiary"
+		},
+	]
+ 
 	custom_fields_quoi = [
 		{
 			"label": "Purchase",
@@ -618,5 +659,6 @@ def get_custom_fields():
 		"Purchase Invoice": custom_fields_pi,
 		"Purchase Order": custom_fields_po,
 		"Purchase Order Item": custom_fields_poi,
+  		"Quotation": custom_fields_quo,
 		"Quotation Item": custom_fields_quoi
 	}

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -179,19 +179,11 @@ def get_custom_fields():
 			"insert_after": "uid"
 		},
 		{
-			"label": "Payment Term",
-			"fieldname": "payment_term",
-			"fieldtype": "Link",
-			"options": "Payment Term",
-			"fetch_from": "customer_subsidiary.payment_term",
-			"insert_after": "customer_subsidiary"
-		},
-		{
 			"label": "Performance Period End",
 			"fieldname": "performance_period_end",
 			"fieldtype": "Date",
 			"description": "Muss gefüllt werden wenn Wartungspositionen in Auftrag gehen.",
-			"insert_after": "payment_term",
+			"insert_after": "customer_subsidiary",
 		},
 		{
 			"label": "Assigned to",
@@ -492,14 +484,6 @@ def get_custom_fields():
 			"options": "Customer Subsidiary",
 			"insert_after": "customer_name",
 		},
-    	{
-			"label": "Payment Term",
-			"fieldname": "payment_term",
-			"fieldtype": "Link",
-			"options": "Payment Term",
-			"fetch_from": "customer_subsidiary.payment_term",
-			"insert_after": "customer_subsidiary"
-		},
 	]
 
 	custom_fields_po = [
@@ -622,14 +606,6 @@ def get_custom_fields():
 			"fieldtype": "Link",
 			"options": "Customer Subsidiary",
 			"insert_after": "party_name",
-		},
-    	{
-			"label": "Payment Term",
-			"fieldname": "payment_term",
-			"fieldtype": "Link",
-			"options": "Payment Term",
-			"fetch_from": "customer_subsidiary.payment_term",
-			"insert_after": "customer_subsidiary"
 		},
 	]
  

--- a/simpatec/simpatec/doctype/customer_subsidiary/customer_subsidiary.json
+++ b/simpatec/simpatec/doctype/customer_subsidiary/customer_subsidiary.json
@@ -16,6 +16,7 @@
   "simpatec_section",
   "assigned_to",
   "column_break_7",
+  "payment_term",
   "sales_section",
   "accounting_section",
   "billing_user_simpatec",
@@ -132,6 +133,12 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "refresh"
+  },
+  {
+   "fieldname": "payment_term",
+   "fieldtype": "Link",
+   "label": "Payment Term",
+   "options": "Payment Term"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -167,9 +174,9 @@
    "link_fieldname": "customer_subsidiary"
   }
  ],
- "modified": "2024-01-11 10:31:43.627509",
+ "modified": "2024-06-12 13:50:56.137766",
  "modified_by": "Administrator",
- "module": "SimpaTec",
+ "module": "Simpatec",
  "name": "Customer Subsidiary",
  "naming_rule": "Set by user",
  "owner": "Administrator",
@@ -188,6 +195,5 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+ "sort_order": "DESC"
 }

--- a/simpatec/simpatec/doctype/customer_subsidiary/customer_subsidiary.json
+++ b/simpatec/simpatec/doctype/customer_subsidiary/customer_subsidiary.json
@@ -138,7 +138,7 @@
    "fieldname": "payment_term",
    "fieldtype": "Link",
    "label": "Payment Term",
-   "options": "Payment Term"
+   "options": "Payment Terms Template"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -174,7 +174,7 @@
    "link_fieldname": "customer_subsidiary"
   }
  ],
- "modified": "2024-06-12 13:50:56.137766",
+ "modified": "2024-06-13 11:34:05.460507",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Customer Subsidiary",


### PR DESCRIPTION
### NOTE: MIGRATION REQUIRED

### Points covered in this PR

1. Added customer subsidiary field in sales order, sales invoice and quotation where it is not avaialble.
2. Added Payment Term Template field in customer subsidiary doctype
3. Added property setter to fetch term template when customer subsidiary is selected in Sales order, Sales Invoice or Quotation.

Preview:
![recording-payment_terms](https://github.com/SimpaTec/simpatec/assets/14124603/4baf03cd-3fb0-490b-8590-c6e75b4acb3f)
