### PR TITLE
Added Customer Filter on customer subsidiary

### DIFF
--- a/simpatec/public/js/quotation.js
+++ b/simpatec/public/js/quotation.js
@@ -92,6 +92,32 @@ frappe.ui.form.on('Quotation', {
 				(ele) => ele.item_language == element
 			).length;
 		}
+
+		frm.set_query("customer_subsidiary", () => {
+			return {
+				filters: {
+					customer: frm.doc.party_name
+				}
+			}
+		});
+	},
+
+	customer_subsidiary: function(frm){
+		frappe.call({
+			'method': 'frappe.client.get',
+			args: {
+				doctype: 'Customer Subsidiary',
+				name: frm.doc.customer_subsidiary
+			},
+			callback: function (data) {
+				let values = {
+					'payment_terms_template': data.message.payment_term,
+				};
+				if(is_null(frm.doc.payment_terms_template)){
+					frm.set_value(values);
+				}
+			}
+		});
 	}
 });
 


### PR DESCRIPTION
### Points covered in this PR

- Added filter in Customer Subsidiary for customer
- Payment term template will only set if it is empty
- ![recording-customer_subsidiary_filter](https://github.com/SimpaTec/simpatec/assets/14124603/823a70fb-99e4-4611-b1e0-8a623bd9aac1)

