### PR TITLE
Issue#39 | Added Get item from Quotation Dialog

### DIFF
--- a/simpatec/events/quotation.py
+++ b/simpatec/events/quotation.py
@@ -1,0 +1,40 @@
+import json
+import frappe
+from frappe import _
+from frappe.utils import cint, cstr, flt, add_days, add_years, today, getdate
+from frappe.model.mapper import get_mapped_doc
+from datetime import date, timedelta, datetime
+from dateutil.relativedelta import relativedelta
+from six import string_types
+
+@frappe.whitelist()
+def make_quotation(source_name: str, target_doc=None):
+	return _make_quotation(source_name, target_doc)
+
+
+def _make_quotation(source_name, target_doc=None, ignore_permissions=False):
+
+
+	def set_missing_values(source, target):
+
+		target.run_method("calculate_taxes_and_totals")
+
+	doclist = get_mapped_doc(
+		"Quotation",
+		source_name,
+		{
+			"Quotation": {"doctype": "Quotation"},
+			"Quotation Item": {
+				"doctype": "Quotation Item",
+				"field_map": {
+					"parent": "prevdoc_docname",
+					"parenttype": "prevdoc_doctype",
+				},
+			},
+		},
+		target_doc,
+		set_missing_values,
+		ignore_permissions=ignore_permissions,
+	)
+
+	return doclist

--- a/simpatec/public/js/quotation.js
+++ b/simpatec/public/js/quotation.js
@@ -49,6 +49,48 @@ frappe.ui.form.on('Quotation', {
 				}
 			});
 		}
+
+
+		// GET ITEMS FROM 
+		if (frm.doc.docstatus === 0) {
+			frm.add_custom_button(__('Quotation'), function () {
+				erpnext.utils.map_current_doc({
+					method: "simpatec.events.quotation.make_quotation",
+					source_doctype: "Quotation",
+					target: frm,
+					size: "extra-large",
+					setters: [
+						{
+							label: "Customer",
+							fieldname: "party_name",
+							fieldtype: "Link",
+							options: "Customer",
+							default: frm.doc.party_name || undefined
+						},
+						{
+							label: "Quotation Label",
+							fieldname: "quotation_label",
+							fieldtype: "Link",
+							options: "Angebotsvorlage",
+							default: frm.doc.quotation_label || undefined
+						},
+						{
+							label: "Item Group",
+							fieldname: "item_group",
+							fieldtype: "Link",
+							options: "Item Group",
+							default: frm.doc.item_group || undefined
+						},
+
+					],
+					get_query_filters: {
+						company: frm.doc.company,
+						docstatus: 1,
+						status: ["!=", "Lost"]
+					}
+				})
+			}, __("Get Items From"));
+		}
     },
 	setup: function(frm){
 		frm.set_query("anschreiben_vorlage", () => {


### PR DESCRIPTION
# Points Covered in this PR
### Gitlab [Issue#39](https://git.phamos.eu/simpatec/P-0142Marketing/-/work_items/39)

1. Added Get items from Quotation feature to get items from other quotations along with some filters and fetch the items from selected Quotation on doclevel item table
<img width="1340" alt="Screenshot 2024-06-26 at 04 23 17" src="https://github.com/SimpaTec/simpatec/assets/14124603/fcc793d6-e810-4564-9c3a-332d852b7598">
<img width="1349" alt="Screenshot 2024-06-26 at 04 23 39" src="https://github.com/SimpaTec/simpatec/assets/14124603/36bcec82-7eea-4fe0-89aa-4fac6adb8c99">
<img width="1333" alt="Screenshot 2024-06-26 at 04 23 55" src="https://github.com/SimpaTec/simpatec/assets/14124603/a85f30b3-ab39-4c36-87db-12b975516d97">
<img width="1330" alt="Screenshot 2024-06-26 at 04 24 07" src="https://github.com/SimpaTec/simpatec/assets/14124603/21c4a3e7-3f61-4683-9545-cf93a298ed81">
