### PR TITLE
Added Permlevel to fields, Changed Label to Software Maintenance

### DIFF
--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.json
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.json
@@ -8,7 +8,7 @@
  "field_order": [
   "sales_section",
   "clearance_item",
-  "background_jobs_section",
+  "software_maintenance_section",
   "auto_reoccurring_maintenance",
   "html_3",
   "danger_zone_section",
@@ -37,7 +37,8 @@
   {
    "fieldname": "update_software_maintenance_items",
    "fieldtype": "Button",
-   "label": "Update Software Maintenance Items"
+   "label": "Update Software Maintenance Items",
+   "permlevel": 1
   },
   {
    "fieldname": "html_1",
@@ -47,18 +48,15 @@
   {
    "fieldname": "html_2",
    "fieldtype": "HTML",
-   "options": "Hitting this button will remove all the items from all the Software Maintenance records and renew them from the Sales Order that is linked in each Software Maintenance Record. Also that record is updated by setting the sales_order_type to \"First Sale\"."
+   "options": "Hitting this button will remove all the items from all the Software Maintenance records and renew them from the Sales Order that is linked in each Software Maintenance Record. Also that record is updated by setting the sales_order_type to \"First Sale\".",
+   "permlevel": 1
   },
   {
    "default": "0",
    "fieldname": "update_timestamp",
    "fieldtype": "Check",
-   "label": "Update Timestamp"
-  },
-  {
-   "fieldname": "background_jobs_section",
-   "fieldtype": "Section Break",
-   "label": "Background Jobs"
+   "label": "Update Timestamp",
+   "permlevel": 1
   },
   {
    "default": "0",
@@ -70,12 +68,17 @@
    "fieldname": "html_3",
    "fieldtype": "HTML",
    "options": "This checkbox will control the behaviour of Reoccurring Maintenance background job if needs to run or not"
+  },
+  {
+   "fieldname": "software_maintenance_section",
+   "fieldtype": "Section Break",
+   "label": "Software Maintenance"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-23 22:39:36.302055",
+ "modified": "2024-06-26 21:09:55.626594",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "SimpaTec Settings",


### PR DESCRIPTION
# Migration Required
# Gitlab [Issue#75](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/75)

### Points Covered in this PR
- Added Perm Level to danger zone field rather to remove or hide it, bacause in future we can have a need to trigger that function, in this case we can handle this from adding perm level and giving the permission to specific role to handle that specific perm level fields. In this case i have added **perm level 1** to control that kind of fields
![recording-perm_level](https://github.com/SimpaTec/simpatec/assets/14124603/b9585551-a1b7-48fc-8f0b-01c7b0246639)
- Changed section Background Job lable to Software Maintenance
<img width="1381" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/d30b6622-919f-4aba-9773-0eac852ffcb7">
