### PR TITLE
Quotation Reoccurring Mandatory Dialog 

### DIFF
--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
@@ -5,20 +5,59 @@ frappe.ui.form.on('Software Maintenance', {
     refresh(frm) {
         var reoccurring_label = __(`${frm.doc.licence_renewal_via} (Reoccurring Maintenance)`)
         frm.add_custom_button(reoccurring_label, function () {
-            frm.events.make_reoccurring(frm)
+            if(frm.doc.licence_renewal_via == "Quotation"){
+                var d = new frappe.ui.Dialog({
+                    title: __('Quotation Mandatory Fields'),
+                    fields: [
+                        {
+                            "label": "Item Group",
+                            "fieldname": "item_group",
+                            "fieldtype": "Link",
+                            "options": "Item Group",
+                            "default": frm.doc.item_group,
+                            "reqd": 1,
+                        },
+                        {
+                            "label": "Quotation Label",
+                            "fieldname": "quotation_label",
+                            "fieldtype": "Link",
+                            "options": "Angebotsvorlage",
+                            "reqd": 1,
+                        },
+                        {
+                            "label": "Ihr Ansprechpartner",
+                            "fieldname": "ihr_ansprechpartner",
+                            "fieldtype": "Link",
+                            "options": "Employee",
+                            "reqd": 1,
+                        },
+
+                    ],
+                    primary_action: function (data) {
+                        debugger;
+                        frm.events.make_reoccurring(frm, data)
+                        d.hide();
+                    },
+                    primary_action_label: __('Create Quotation')
+                });
+                d.show();
+            }else{
+                frm.events.make_reoccurring(frm)
+            }
         }, __("Create"));
 
 
         //hide all + in the connection
         $('.form-documents button').hide();
     },
-    make_reoccurring(frm){
+    make_reoccurring(frm, mandatory_fields){
         frappe.call({
             method: "simpatec.simpatec.doctype.software_maintenance.software_maintenance.make_reoccuring_sales_order",
             args: {
                 software_maintenance: frm.doc.name,
                 is_background_job: 0,
-                licence_renewal_via: frm.doc.licence_renewal_via
+                licence_renewal_via: frm.doc.licence_renewal_via,
+                mandatory_fields: mandatory_fields
             },
             callback: function (r) {
             },

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, add_days, add_years, getdate, today
+import json
 from datetime import timedelta
 
 class SoftwareMaintenance(Document):
@@ -28,7 +29,7 @@ class SoftwareMaintenance(Document):
 
 
 @frappe.whitelist()
-def make_reoccuring_sales_order(software_maintenance, licence_renewal_via=None, is_background_job=True):
+def make_reoccuring_sales_order(software_maintenance, licence_renewal_via=None, mandatory_fields=None, is_background_job=True):
 	if licence_renewal_via == None or licence_renewal_via == "":
 		frappe.throw("Select Licence Renewal before creating Reoccurring Maintenance")
 	software_maintenance = frappe.get_doc("Software Maintenance", software_maintenance)
@@ -64,6 +65,9 @@ def make_reoccuring_sales_order(software_maintenance, licence_renewal_via=None, 
 	reoccurring_order.ihr_ansprechpartner = employee
 	reoccurring_order.transaction_date = transaction_date
 	reoccurring_order.order_type = "Sales"
+	if mandatory_fields:
+		mandatory_fields = json.loads(mandatory_fields)
+		reoccurring_order.update(mandatory_fields)
 
 	for item in software_maintenance.items:
 		reoccurring_order.append("items", {


### PR DESCRIPTION
# Points Covered in this PR
# Gitlab [Issue#52](https://git.phamos.eu/simpatec/P-0142Marketing/-/issues/15?work_item_iid=52)
- Added dialog box for asking mandatory values before creating quotation (reoccurring maintenance)
<img width="1363" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/0001be3d-d20d-4380-b67d-20de47d59f14">
<img width="1351" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/a8e964ee-3bd6-4ae8-b47b-407935826411">
![recording-quotation_mandatory](https://github.com/SimpaTec/simpatec/assets/14124603/bfc21ed3-01e5-4eb2-9aed-986dc122188e)

