### PR TITLE
P-0014 #80 removed appended items and added SO link in items

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -108,7 +108,8 @@ def update_software_maintenance(doc, method=None):
 					software_maintenance.performance_period_end = doc.performance_period_end
 			
 		software_maintenance.sale_order = doc.name
-		software_maintenance.items = []
+		if doc.sales_order_type == "Reoccuring Maintenance":
+			software_maintenance.items = []
 		for item in doc.items:
 			item_rate = item.rate
 			item_reoccurring_maintenance_amount = item.reoccurring_maintenance_amount

--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -108,6 +108,7 @@ def update_software_maintenance(doc, method=None):
 					software_maintenance.performance_period_end = doc.performance_period_end
 			
 		software_maintenance.sale_order = doc.name
+		software_maintenance.items = []
 		for item in doc.items:
 			item_rate = item.rate
 			item_reoccurring_maintenance_amount = item.reoccurring_maintenance_amount
@@ -168,7 +169,8 @@ def update_software_maintenance(doc, method=None):
 				"reoccurring_maintenance_amount": item_reoccurring_maintenance_amount,
 				"qty": item.qty,
 				"uom": item.uom,
-				"purchase_price": item.purchase_price
+				"purchase_price": item.purchase_price,
+				"sales_order": doc.name
 			})
 
 		software_maintenance.save()

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -83,7 +83,8 @@ def make_reoccuring_sales_order(software_maintenance, licence_renewal_via=None, 
 			"delivery_date": reoccurring_order.transaction_date,
 			"start_date": item.start_date,
 			"end_date": item.end_date,
-			"purchase_price": item.purchase_price
+			"purchase_price": item.purchase_price,
+   			"price_list_rate": item.price_list_rate
 		})
 
 	reoccurring_order.insert()

--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -22,7 +22,9 @@
   "rate",
   "price_list_rate",
   "purchase_section",
-  "purchase_price"
+  "purchase_price",
+  "references_section",
+  "sales_order"
  ],
  "fields": [
   {
@@ -162,11 +164,22 @@
    "fieldname": "purchase_price",
    "fieldtype": "Currency",
    "label": "Purchase Price"
+  },
+  {
+   "fieldname": "references_section",
+   "fieldtype": "Section Break",
+   "label": "References"
+  },
+  {
+   "fieldname": "sales_order",
+   "fieldtype": "Link",
+   "label": "Sales Order",
+   "options": "Sales Order"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-05-30 10:10:55.722159",
+ "modified": "2024-07-08 12:28:26.586468",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Software Maintenance Item",


### PR DESCRIPTION
# Migration Required
## Gitlab [Issue#80](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/80)
### Points Covered in this PR

- Item will not append in Software maintenance item table after submission of Reoccurring Sales Order. Software Maintenance table will be updated by new items only. Previous items will be removed.
![recording-append_items](https://github.com/SimpaTec/simpatec/assets/14124603/44f18dd6-85e2-4594-aa0a-7fa8b8676b0d)

- Added Sales Order Reference Link in Software Maintenance Line Items.
<img width="765" alt="image" src="https://github.com/SimpaTec/simpatec/assets/14124603/da5bde56-b80e-4412-9ff4-46a01b7164cd">
