### PR TITLE
Added Inflation Item in Software Maintenance Items

### DIFF
--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
@@ -62,6 +62,42 @@ frappe.ui.form.on('Software Maintenance', {
             callback: function (r) {
             },
         });
+    },
+
+    set_inflation(frm){
+        var inflation_item = frappe.call({
+            method: 'frappe.client.get_value',
+            args: {
+                'doctype': 'Item',
+                'filters': { 'item_type': "Inflation Item" },
+                'fieldname': [
+                    'name',
+                    'item_name',
+                    'stock_uom'                 
+                ]
+            },
+            async: false,
+            callback: function (r) {
+                if (!r.exc) { 
+                    $.each(frm.doc.items, function (k, v) {
+                        if (v.item_type == "Maintenance Item") {
+                            // Add inflation Item next to Maintenance Item
+                            let item_row = cur_frm.add_child("items");
+                            frappe.model.set_value(item_row.doctype, item_row.name, "item_code", r.message.name);
+                            frappe.model.set_value(item_row.doctype, item_row.name, "item_name", r.message.item_name);
+                            frappe.model.set_value(item_row.doctype, item_row.name, "uom", r.message.stock_uom);
+                            frappe.model.set_value(item_row.doctype, item_row.name, "description", `Adding ${frm.doc.inflation_rate}% Inflation Rate from the ${frm.doc.inflation_valid_from}`);
+                            frm.doc.items.splice(k+1, 0, item_row);
+                            frm.doc.items.pop()
+                        }
+                    })
+                    frm.refresh_field("items");
+                    frm.fields_dict["items"].grid.renumber_based_on_dom()
+                    frm.refresh_field("items");  
+                }
+            }
+        });
+        
     }
 });
 

--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -9,6 +9,7 @@
  "field_order": [
   "item_code",
   "item_name",
+  "item_type",
   "description",
   "item_group",
   "item_language",
@@ -175,11 +176,18 @@
    "fieldtype": "Link",
    "label": "Sales Order",
    "options": "Sales Order"
+  },
+  {
+   "fetch_from": "item_code.item_type",
+   "fieldname": "item_type",
+   "fieldtype": "Data",
+   "label": "Item Type",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-07-08 12:28:26.586468",
+ "modified": "2024-07-11 09:14:09.080755",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Software Maintenance Item",


### PR DESCRIPTION
# Migration Required
## [Issue#63](https://git.phamos.eu/simpatec/P-0142Marketing/-/issues/17?work_item_iid=63)
### Points Covered in this PR
- Added Inflation Items in software maintenance item table after every maintenance Items on trigger of set inflation buttons
- Added Item Type field in Software Maintenance Item for the identification of maintenance Item

Preview
![recording-inflation_item_sm_append](https://github.com/SimpaTec/simpatec/assets/14124603/1e7a9450-cef5-4f10-b8e3-422f3a01e2d0)
