### PR TITLE
Inflation Item Calculation on Software maintenance Items

### DIFF
--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
@@ -83,9 +83,16 @@ frappe.ui.form.on('Software Maintenance', {
                     $.each(frm.doc.items, function (k, v) {
                         if (v.item_type == "Maintenance Item") {
                             // Inflation Rate calculation
-                            var inflation_rate = frm.doc.inflation_rate
-                            var inflation_amount = (v.reoccurring_maintenance_amount * inflation_rate) / 100
-                            var increased_reoccurring_amount = v.reoccurring_maintenance_amount + inflation_amount
+                            var inflation_rate = 0
+                            var inflation_amount = 0
+                            var increased_reoccurring_amount = 0
+                            
+                            if(v.start_date > frm.doc.inflation_valid_from){
+                                var inflation_rate = frm.doc.inflation_rate
+                                var inflation_amount = (v.reoccurring_maintenance_amount * inflation_rate) / 100
+                                var increased_reoccurring_amount = v.reoccurring_maintenance_amount + inflation_amount
+                            }
+
                             // Add inflation Item next to Maintenance Item
                             let item_row = cur_frm.add_child("items");
                             frappe.model.set_value(item_row.doctype, item_row.name, "item_code", r.message.name);
@@ -98,6 +105,7 @@ frappe.ui.form.on('Software Maintenance', {
                             
                             // New Increase Reoccurring Amount 
                             frappe.model.set_value(v.doctype, v.name, "reoccurring_maintenance_amount", increased_reoccurring_amount)
+                            
                             frm.doc.items.splice(k+1, 0, item_row);
                             frm.doc.items.pop()
                         }

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
@@ -73,7 +73,8 @@ frappe.ui.form.on('Software Maintenance', {
                 'fieldname': [
                     'name',
                     'item_name',
-                    'stock_uom'                 
+                    'stock_uom',
+                    'item_type'                
                 ]
             },
             async: false,
@@ -81,12 +82,22 @@ frappe.ui.form.on('Software Maintenance', {
                 if (!r.exc) { 
                     $.each(frm.doc.items, function (k, v) {
                         if (v.item_type == "Maintenance Item") {
+                            // Inflation Rate calculation
+                            var inflation_rate = frm.doc.inflation_rate
+                            var inflation_amount = (v.reoccurring_maintenance_amount * inflation_rate) / 100
+                            var increased_reoccurring_amount = v.reoccurring_maintenance_amount + inflation_amount
                             // Add inflation Item next to Maintenance Item
                             let item_row = cur_frm.add_child("items");
                             frappe.model.set_value(item_row.doctype, item_row.name, "item_code", r.message.name);
                             frappe.model.set_value(item_row.doctype, item_row.name, "item_name", r.message.item_name);
                             frappe.model.set_value(item_row.doctype, item_row.name, "uom", r.message.stock_uom);
+                            frappe.model.set_value(item_row.doctype, item_row.name, "item_type", r.message.item_type);
+                            frappe.model.set_value(item_row.doctype, item_row.name, "rate", inflation_amount);
+                            frappe.model.set_value(item_row.doctype, item_row.name, "price_list_rate", inflation_amount);
                             frappe.model.set_value(item_row.doctype, item_row.name, "description", `Adding ${frm.doc.inflation_rate}% Inflation Rate from the ${frm.doc.inflation_valid_from}`);
+                            
+                            // New Increase Reoccurring Amount 
+                            frappe.model.set_value(v.doctype, v.name, "reoccurring_maintenance_amount", increased_reoccurring_amount)
                             frm.doc.items.splice(k+1, 0, item_row);
                             frm.doc.items.pop()
                         }

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.json
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.json
@@ -264,6 +264,7 @@
    "label": "Valid from"
   },
   {
+   "depends_on": "eval: doc.inflation_rate > 0 && doc.docstatus == 0",
    "fieldname": "set_inflation",
    "fieldtype": "Button",
    "label": "Set Inflation"
@@ -301,7 +302,7 @@
    "link_fieldname": "software_maintenance"
   }
  ],
- "modified": "2024-07-10 18:23:06.613070",
+ "modified": "2024-07-11 11:30:44.529117",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Software Maintenance",


### PR DESCRIPTION
# Migration Required
## [Issue#62](https://git.phamos.eu/simpatec/P-0142Marketing/-/issues/17?work_item_iid=62)
### Points Covered in this PR

#### Added Calculation of the Inflation Item
- Item Rate of the inflation item will be calculated from maintenance item, the formula will be: (reoccurring_amount * rate_percentage of inflation item) = some amount
- Inflation item rate will be then added to maintenance item reoccurring_maintenance_amount which will be the new increased reoccurring maintenance amount of the Maintenance item
- Rate calculation on maintenance items will only apply if the start date of item will be greater than the inflation valid from date

Preview of the Process
![recording-inflation_item_calculation](https://github.com/SimpaTec/simpatec/assets/14124603/10883193-9463-4356-a5e3-3abe0f76ccc1)
