### PR TITLE
Stop Inflation Item from being tranferred from SO to SM

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -111,6 +111,8 @@ def update_software_maintenance(doc, method=None):
 		if doc.sales_order_type == "Reoccuring Maintenance":
 			software_maintenance.items = []
 		for item in doc.items:
+			if item.item_type == "Inflation Item":
+				continue
 			item_rate = item.rate
 			item_reoccurring_maintenance_amount = item.reoccurring_maintenance_amount
 			item_start_date = item.start_date


### PR DESCRIPTION
# Migration Required
## [Issue#61](https://git.phamos.eu/simpatec/P-0142Marketing/-/issues/17?work_item_iid=61)
### Points Covered in this PR

- Inflation Item will not be transferred from Sales order to Software Maintenance on Reoccurring Maintenance Update. - --
- Inflation rates need to applied again on next reoccurring maintenance.

Preview Or the task
![recording-inflation_item_remove_from_so_to_sm](https://github.com/SimpaTec/simpatec/assets/14124603/30618939-08f1-43d0-87e0-aa9ee884bf28)

