### PR TITLE
Conditional Mandatory property on Start End Date, Refactor Code

### DIFF
--- a/simpatec/public/js/quotation.js
+++ b/simpatec/public/js/quotation.js
@@ -48,11 +48,8 @@ frappe.ui.form.on('Quotation', {
 					addClearIconToField(field);
 				}
 			});
-		}
-
-
-		// GET ITEMS FROM 
-		if (frm.doc.docstatus === 0) {
+			
+			// GET ITEMS FROM 
 			frm.add_custom_button(__('Quotation'), function () {
 				erpnext.utils.map_current_doc({
 					method: "simpatec.events.quotation.make_quotation",
@@ -90,6 +87,9 @@ frappe.ui.form.on('Quotation', {
 					}
 				})
 			}, __("Get Items From"));
+
+			// Add Conditional Mandatory On Start/End Dates
+			frm.events.start_end_date_conditional_mandatory(frm)
 		}
     },
 	setup: function(frm){
@@ -162,7 +162,23 @@ frappe.ui.form.on('Quotation', {
 				}
 			}
 		});
-	}
+	},
+
+	sales_order_type: function(frm){
+		// Add Conditional Mandatory On Start/End Dates
+		frm.events.start_end_date_conditional_mandatory(frm)
+	},
+
+	start_end_date_conditional_mandatory: function (frm) {
+		if (["Reoccuring Maintenance"].includes(frm.doc.sales_order_type)) {
+			frm.toggle_reqd("performance_period_start", 1)
+			frm.toggle_reqd("performance_period_end", 1)
+		}
+		else {
+			frm.toggle_reqd("performance_period_start", 0)
+			frm.toggle_reqd("performance_period_end", 0)
+		}
+	},
 });
 
 frappe.ui.form.on('Quotation Item',{

--- a/simpatec/public/js/sales_order.js
+++ b/simpatec/public/js/sales_order.js
@@ -63,18 +63,11 @@ frappe.ui.form.on('Sales Order', {
     refresh(frm) {
 
         if(frm.doc.docstatus == 0){
-            if(frm.doc.sales_order_type == "First Sale") {
-                frm.toggle_enable("software_maintenance", 0)
-                frm.toggle_reqd("software_maintenance", 0)
-            } 
-            else if (["Follow-Up Sale", "Reoccuring Maintenance"].includes(frm.doc.sales_order_type)) {
-                frm.toggle_reqd("software_maintenance", 1)
-                frm.toggle_enable("software_maintenance", 1)
-            }
-            else{
-                frm.toggle_reqd("software_maintenance", 0)
-                frm.toggle_enable("software_maintenance", 1)
-            }
+            // Conditional Enable and required Toggle on Software Maintenance
+            frm.events.software_maintenance_conditional_toggle_reqd(frm)
+
+            // Add Conditional Mandatory On Start/End Dates
+            frm.events.start_end_date_conditional_mandatory(frm)
         }
 
         // GET SIMPATEC GLOBAL SETTINGS
@@ -152,11 +145,17 @@ frappe.ui.form.on('Sales Order', {
             $("div[data-fieldname='sales_order_clearances']").parents(".form-column").removeClass("col-md-12")
         }
 
-        if(frm.doc.sales_order_type == "First Sale") {
+        // Conditional Enable and required Toggle on Software Maintenance
+        frm.events.software_maintenance_conditional_toggle_reqd(frm)
+        
+        // Add Conditional Mandatory On Start/End Dates
+        frm.events.start_end_date_conditional_mandatory(frm)
+    },
+
+    software_maintenance_conditional_toggle_reqd(frm){
+        if (frm.doc.sales_order_type == "First Sale") {
             frm.toggle_enable("software_maintenance", 0)
             frm.toggle_reqd("software_maintenance", 0)
-            // frm.toggle_enable("performance_period_start", 1)
-            // frm.toggle_enable("performance_period_end", 1)
         }
         else if (["Follow-Up Sale", "Reoccuring Maintenance"].includes(frm.doc.sales_order_type)) {
             frm.toggle_reqd("software_maintenance", 1)
@@ -166,9 +165,19 @@ frappe.ui.form.on('Sales Order', {
             frm.toggle_reqd("software_maintenance", 0)
             frm.toggle_enable("software_maintenance", 1)
         }
-        
-  
     },
+
+    start_end_date_conditional_mandatory: function(frm){
+        if (["First Sale", "Follow-Up Sale", "Reoccuring Maintenance", "RTO", "Subscription Annual"].includes(frm.doc.sales_order_type)) {
+            frm.toggle_reqd("performance_period_start", 1)
+            frm.toggle_reqd("performance_period_end", 1)
+        }
+        else {
+            frm.toggle_reqd("performance_period_start", 0)
+            frm.toggle_reqd("performance_period_end", 0)
+        }
+    },  
+    
     performance_period_start: function (frm) {
         var currentDate = moment(frm.doc.performance_period_start);
         var futureMonth = moment(currentDate).add(364, 'd');


### PR DESCRIPTION
# Migration Required
## [Gitlab Issue#86](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/67?work_item_iid=86#note_4018)
### Points Covered in this PR
- Added Conditional Mandatory Property on Start/End Date in Quotation and Sales Order
- Refactor Code in Sales order and Quotation
#### Reference for Conditions
<img width="336" alt="Screenshot 2024-07-12 at 16 03 34" src="https://github.com/user-attachments/assets/0776bf6d-247a-472e-9a67-cd86a8418723">

## Preview 
**Result can be match with above reference**
#### Sales Order
![recording-mandatory_so](https://github.com/user-attachments/assets/e226826d-e778-4fd2-b3f2-bfe467a33b87)

#### Quotation
![recording-mandatory_quo](https://github.com/user-attachments/assets/a4aed4df-3c4e-4ab0-92f3-d63811085584)
