### PR TITLE
Item price list software maintenance

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -126,6 +126,7 @@ def update_software_maintenance(doc, method=None):
 				item_rate = item.reoccurring_maintenance_amount
 			else:
 				item_rate = 0
+				item.price_list_rate = 0
 				item_reoccuring_maintenance_amount = 0
 			if type(item_start_date) == str:
 				item_start_date = datetime.strptime(item_start_date, "%Y-%m-%d").date()

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.py
@@ -70,6 +70,9 @@ def make_reoccuring_sales_order(software_maintenance, licence_renewal_via=None, 
 		reoccurring_order.update(mandatory_fields)
 
 	for item in software_maintenance.items:
+		item_type = frappe.db.get_value("Item", item.item_code, "item_type")
+		if item_type != "Maintenance Item":
+			item.price_list_rate = 0
 		reoccurring_order.append("items", {
 			"item_code": item.item_code,
 			"item_name": item.item_name,


### PR DESCRIPTION
## [Gitlab Issue#81](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/77?work_item_iid=81)
### Points Covered in this PR
- the price_list_rate are transferring forward from software maintenance to sales order/quotation and transferring back to software maintenance, but only for the maintenance item, the non maintenance item will not have any price_list_rate or rate, it will have zero on rate or price_list_rate
### Preview

![recording-price_list_rate](https://github.com/user-attachments/assets/a23b2415-47ad-42ba-864f-23a9594ed844)
**Note: Ignore the items that are being appended in the software maintenance items. It has been already solved.**

