### PR TITLE
Allow the change of item name and description after saving Software Maintenance

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -68,6 +68,7 @@ def make_software_maintenance(source_name, target_doc=None):
 					item.rate = 0
 					item.reoccurring_maintenance_amount = 0
 		doc.assign_to = source.assigned_to
+		doc = set_translated_description(doc)
 
 	doc = get_mapped_doc(
 		"Sales Order",
@@ -87,6 +88,15 @@ def make_software_maintenance(source_name, target_doc=None):
 		postprocess,
 	)
 
+	return doc
+
+def set_translated_description(doc):
+	for item in doc.items:
+		description_en, description_de, description_fr = frappe.db.get_value("Item", item.item_code, ["id_en", "id_de", "id_fr"])
+
+		item.description_en = description_en
+		item.description_de = description_de
+		item.description_fr = description_fr
 	return doc
 
 @frappe.whitelist()

--- a/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
+++ b/simpatec/simpatec/doctype/software_maintenance/software_maintenance.js
@@ -172,4 +172,14 @@ var set_right_translation = function(frm, cdt, cdn){
         grid.update_docfield_property("description_fr", "hidden", 0)
     }
     grid.refresh();
+
+    var item_code = frappe.model.get_value(cdt, cdn, "item_code")
+    frappe.db.get_value("Item", item_code, ["in_en", "id_en", "in_de", "id_de", "in_fr", "id_fr"]).then((r) => {
+        frappe.model.set_value(cdt, cdn, "item_name_en", r.message.in_en)
+        frappe.model.set_value(cdt, cdn, "description_en", r.message.id_en)
+        frappe.model.set_value(cdt, cdn, "item_name_de", r.message.in_de)
+        frappe.model.set_value(cdt, cdn, "description_de", r.message.id_de)
+        frappe.model.set_value(cdt, cdn, "item_name_fr", r.message.in_fr)
+        frappe.model.set_value(cdt, cdn, "description_fr", r.message.id_fr)
+    })
 }

--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -48,7 +48,6 @@
    "width": "150px"
   },
   {
-   "fetch_from": "item_code.in_en",
    "fieldname": "item_name_en",
    "fieldtype": "Data",
    "in_global_search": 1,
@@ -61,7 +60,6 @@
    "width": "150"
   },
   {
-    "fetch_from": "item_code.id_en",
     "fieldname": "description_en",
     "fieldtype": "Text Editor",
     "label": "Description EN",
@@ -72,7 +70,6 @@
     "width": "300px"
   },
   {
-    "fetch_from": "item_code.in_de",
     "fieldname": "item_name_de",
     "fieldtype": "Data",
     "in_global_search": 1,
@@ -85,7 +82,6 @@
     "width": "150"
   },
   {
-    "fetch_from": "item_code.id_de",
     "fieldname": "description_de",
     "fieldtype": "Text Editor",
     "label": "Description DE",
@@ -96,7 +92,6 @@
     "width": "300px"
   },
   {
-    "fetch_from": "item_code.in_fr",
     "fieldname": "item_name_fr",
     "fieldtype": "Data",
     "in_global_search": 1,
@@ -109,7 +104,6 @@
     "width": "150"
   },
   {
-    "fetch_from": "item_code.id_fr",
     "fieldname": "description_fr",
     "fieldtype": "Text Editor",
     "label": "Description FR",


### PR DESCRIPTION
Fixing issue with #138 

- Allow the change of item name and description after saving Software Maintenance
- If we create Software Maintenance from Sales Order, the description fields are set according to the item_language.

![Kazam_screencast_00287](https://github.com/user-attachments/assets/df285f7a-cebf-4a3c-901f-d2dd121e2dbe)
