### PR TITLE
Added New Item Description Fields in Sales Order Item

### DIFF
--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -381,7 +381,37 @@ def get_custom_fields():
 			"depends_on": "eval:doc.item_language == 'fr'",
 			"insert_after": "item_name_de",
 		},
-
+  
+		# NEW ITEM DESCRIPTION FIELDS
+		{
+			"label": "Item Description EN",
+			"fieldname": "item_description_en",
+			"fieldtype": "Text Editor",
+			"fetch_from": "item_code.id_en",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'en'",
+			"insert_after": "description",
+		},
+		{
+			"label": "Item Description DE",
+			"fieldname": "item_description_de",
+			"fieldtype": "Text Editor",
+			"fetch_from": "item_code.id_de",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'de'",
+			"insert_after": "item_description_en",
+		},
+		{
+			"label": "Item Description FR",
+			"fieldname": "item_description_fr",
+			"fieldtype": "Text Editor",
+			"fetch_from": "item_code.in_fr",
+			"fetch_if_empty": 1,
+			"depends_on": "eval:doc.item_language == 'fr'",
+			"insert_after": "item_description_de",
+		},
+		# END NEW ITEM DESCRIPTION FIELDS
+  
 		{
 			"label": "Item Description EN",
 			"fieldname": "id_en",


### PR DESCRIPTION
# Migration Required
## Gitlab Issue [#92](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/89?work_item_iid=92)
### Points covered in this PR

- Added New item description field in Sales Order Item with naming standard of item_description_xx where xx is language e.g en, de, fr

### Preview:
![recording-iitem_description_soi](https://github.com/user-attachments/assets/67f88ccb-953c-48cf-886b-e3d79e3c6e1d)
