### PR TITLE
Fixed Item name Transferreing Issue

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -163,6 +163,9 @@ def update_software_maintenance(doc, method=None):
 			software_maintenance.append("items", {
 				"item_code": item.item_code,
 				"item_name": item.item_name,
+				"item_name_en": item.item_name_en,
+				"item_name_de": item.item_name_de,
+				"item_name_fr": item.item_name_fr,
 				"description": item.description,
 				"item_language": item.item_language,
 				"item_description_en": item.item_description_en,


### PR DESCRIPTION
Issue Fixed, Mentioned Below
- Item Name for different languages was not transferring from Sales Order to Software Maintenance while updating reoccurring maintenance.