### PR TITLE
Added Script for Item Description

### DIFF
--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.js
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.js
@@ -4,10 +4,27 @@
 frappe.ui.form.on('SimpaTec Settings', {
 	update_software_maintenance_items: function(frm){
 		frm.call({
-			method: "simpatec.simpatec.doctype.simpatec_settings.simpatec_settings.update_software_maintenance_items",
+			method: "update_software_maintenance_items",
+			doc: frm.doc,
 			args: {
 				update_timestamp: frm.doc.update_timestamp
 			},
+			callback: function (r) {
+				if (r.message) {
+					frappe.msgprint(r.message)
+				}
+			}
+		})
+	},
+	update_item_fieds: function(frm){
+		frm.call({
+			method: "update_item_details",
+			doc: frm.doc,
+			args: {
+				update_timestamp: frm.doc.update_timestamp
+			},
+			freeze: 1,
+			freeze_message: __("Updating System"),
 			callback: function (r) {
 				if (r.message) {
 					frappe.msgprint(r.message)

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.json
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.json
@@ -15,7 +15,9 @@
   "html_1",
   "update_software_maintenance_items",
   "update_timestamp",
-  "html_2"
+  "html_2",
+  "html_4",
+  "update_item_fieds"
  ],
  "fields": [
   {
@@ -48,7 +50,7 @@
   {
    "fieldname": "html_2",
    "fieldtype": "HTML",
-   "options": "Hitting this button will remove all the items from all the Software Maintenance records and renew them from the Sales Order that is linked in each Software Maintenance Record. Also that record is updated by setting the sales_order_type to \"First Sale\".",
+   "options": "Hitting this button will remove all the items from all the Software Maintenance records and renew them from the Sales Order that is linked in each Software Maintenance Record. Also that record is updated by setting the sales_order_type to \"First Sale\".\n<hr>",
    "permlevel": 1
   },
   {
@@ -73,12 +75,22 @@
    "fieldname": "software_maintenance_section",
    "fieldtype": "Section Break",
    "label": "Software Maintenance"
+  },
+  {
+   "fieldname": "update_item_fieds",
+   "fieldtype": "Button",
+   "label": "Update Item Fieds"
+  },
+  {
+   "fieldname": "html_4",
+   "fieldtype": "HTML",
+   "options": "<p style=\"color: red;\">Careful: Clicking this button will execute a script that transfers data from old fields to new fields and makes significant alterations to the field contents, potentially causing irreversible changes. Please consult higher management before proceeding with this action.</p>\n"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-06-26 21:09:55.626594",
+ "modified": "2024-07-30 13:24:07.745835",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "SimpaTec Settings",

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
@@ -7,96 +7,144 @@ from datetime import timedelta
 from frappe.utils import now
 
 class SimpaTecSettings(Document):
-    pass
+    @frappe.whitelist()
+    def update_item_details(self):
+        try:
+            
+            # Update item descriptions data from old field id_xx to new field item_description_xx
+            
+            # SOFTWARE MAINTENANCE ITEM
+            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `id_en`, `item_description_fr` = `id_fr`,`item_description_de` = `id_de`")
+                
+            # SALES ORDER ITEM
+            if frappe.db.exists("Custom Field", "Sales Order Item-id_en"):
+                frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `id_en`")
+                # frappe.delete_doc("Custom Field", "Sales Order Item-id_en", force=1)
+            if frappe.db.exists("Custom Field", "Sales Order Item-id_fr"):
+                frappe.db.sql("update `tabSales Order Item` set `item_description_fr` = `id_fr`")
+                # frappe.delete_doc("Custom Field", "Sales Order Item-id_fr", force=1)
+            if frappe.db.exists("Custom Field", "Sales Order Item-id_de"):
+                frappe.db.sql("update `tabSales Order Item` set `item_description_de` = `id_de`")
+                # frappe.delete_doc("Custom Field", "Sales Order Item-id_de", force=1)
+                
 
-@frappe.whitelist()
-def update_software_maintenance_items(update_timestamp=None):
-    try:
-        frappe.publish_progress(0, title='Updating Software Maintenances', description='Starting update...')
-        # Remove Wrong field of reccuring_maintenance_amount and reoccuring_maintenance_amount if exist
-        if frappe.db.exists("Custom Field", "Sales Order Item-reoccuring_maintenance_amount"):
-            frappe.delete_doc("Custom Field", "Sales Order Item-reoccuring_maintenance_amount", force=1)
-        if frappe.db.exists("Custom Field", "Sales Order Item-reccuring_maintenance_amount"):
-            # First set the value of wrong `reoccurring_maintenance_amount` field into `reoccurring_maintenance_amount`
-            frappe.db.sql("update `tabSales Order Item` set `reoccurring_maintenance_amount` = `reccuring_maintenance_amount` where item_type = 'Maintenance Item'")
-            # Now removing the field
-            frappe.delete_doc("Custom Field", "Sales Order Item-reccuring_maintenance_amount", force=1)
-        if frappe.db.exists("Custom Field", "Sales Order Item-einkaufspreis"):
-            # first update the field value into new one
-            frappe.db.sql("update `tabSales Order Item` set `purchase_price` = `einkaufspreis` ")
-            # now remove the field and its section
-            frappe.delete_doc("Custom Field", "Sales Order Item-einkauf", force=1) # section
-            frappe.delete_doc("Custom Field", "Sales Order Item-einkaufspreis", force=1) # field
-        
-        update_timestamp = int(update_timestamp)
-        """Query for removing all previous Software maintenance Items"""
-        frappe.db.sql("DELETE FROM `tabSoftware Maintenance Item`")
-        software_maintenances = frappe.get_all("Software Maintenance", fields=["sales_order", "name"], filters=[["sales_order","is","set"]])
-        total_rows = len(software_maintenances)
-        for index, s_m in enumerate(software_maintenances):
-            so_items = frappe.get_all("Sales Order Item", filters={"parent": s_m.sales_order}, fields=["*"])
-            if len(so_items) > 0:
-                for item in so_items:   
-                    software_maintenance_items = frappe.new_doc("Software Maintenance Item")
+            # QUOTATION ITEM
+            if frappe.db.exists("Custom Field", "Quotation Item-id_en"):
+                frappe.db.sql("update `tabQuotation Item` set `item_description_en` = `id_en`")
+                # frappe.delete_doc("Custom Field", "Sales Order Item-id_en", force=1)
+            if frappe.db.exists("Custom Field", "Quotation Item-id_fr"):
+                frappe.db.sql("update `tabQuotation Item` set `item_description_fr` = `id_fr`")
+                # frappe.delete_doc("Custom Field", "Sales Order Item-id_fr", force=1)
+            if frappe.db.exists("Custom Field", "Quotation Item-id_de"):
+                frappe.db.sql("update `tabQuotation Item` set `item_description_de` = `id_de`")
+                # frappe.delete_doc("Custom Field", "Quotation Item-id_fr", force=1)
+            
+            modified_by = frappe.session.user
+            update_timestamp = int(self.update_timestamp)
+            
+            if update_timestamp:
+                frappe.db.sql("""update `tabSoftware Maintenance` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2""".format(modified= now(), modified_by= modified_by))
+                frappe.db.sql("""update `tabSales Order` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2 """.format(modified= now(), modified_by= modified_by))
+                frappe.db.sql("""update `tabQuotation` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2 """.format(modified= now(), modified_by= modified_by))
+                
+            return {"message":"""<h3>The script has run and had updated all Item Descriptions in Software Maintenance, Sales Order and Quotation:</h3>
+                    <ul>
+                        <li>Copied the old item description data from id_xx field to item_description_xx</li>
+                    </ul>
+                    <p>For further information check in SimpaTec Settings page and consult your project manager.</p> """, "title": "Success"}   
+        except Exception as ex:
+            frappe.db.rollback()
+            frappe.log_error(ex)
+            return {"message":"There was some error occured in the process, Please check error logs.", "title":"Error" }
 
-                    if item.start_date is not None:
-                        item.start_date = item.start_date + timedelta(days=365)
-                    if item.end_date is not None:
-                        item.end_date = item.end_date + timedelta(days=365)
-                        if item.start_date is not None and item.end_date is not None:
-                            days_diff = item.end_date - item.start_date
-                            if days_diff == 365:
-                                item.end_date = item.end_date - timedelta(days=1)
-                    if item.item_type == "Maintenance Item":
-                        item.rate = item.reoccurring_maintenance_amount
-                        item.reoccurring_maintenance_amount = item.reoccurring_maintenance_amount
+    @frappe.whitelist()
+    def update_software_maintenance_items(self):
+        try:
+            frappe.publish_progress(0, title='Updating Software Maintenances', description='Starting update...')
+            # Remove Wrong field of reccuring_maintenance_amount and reoccuring_maintenance_amount if exist
+            if frappe.db.exists("Custom Field", "Sales Order Item-reoccuring_maintenance_amount"):
+                frappe.delete_doc("Custom Field", "Sales Order Item-reoccuring_maintenance_amount", force=1)
+            if frappe.db.exists("Custom Field", "Sales Order Item-reccuring_maintenance_amount"):
+                # First set the value of wrong `reoccurring_maintenance_amount` field into `reoccurring_maintenance_amount`
+                frappe.db.sql("update `tabSales Order Item` set `reoccurring_maintenance_amount` = `reccuring_maintenance_amount` where item_type = 'Maintenance Item'")
+                # Now removing the field
+                frappe.delete_doc("Custom Field", "Sales Order Item-reccuring_maintenance_amount", force=1)
+            if frappe.db.exists("Custom Field", "Sales Order Item-einkaufspreis"):
+                # first update the field value into new one
+                frappe.db.sql("update `tabSales Order Item` set `purchase_price` = `einkaufspreis` ")
+                # now remove the field and its section
+                frappe.delete_doc("Custom Field", "Sales Order Item-einkauf", force=1) # section
+                frappe.delete_doc("Custom Field", "Sales Order Item-einkaufspreis", force=1) # field
+            
+            update_timestamp = int(self.update_timestamp)
+            """Query for removing all previous Software maintenance Items"""
+            frappe.db.sql("DELETE FROM `tabSoftware Maintenance Item`")
+            software_maintenances = frappe.get_all("Software Maintenance", fields=["sales_order", "name"], filters=[["sales_order","is","set"]])
+            total_rows = len(software_maintenances)
+            for index, s_m in enumerate(software_maintenances):
+                so_items = frappe.get_all("Sales Order Item", filters={"parent": s_m.sales_order}, fields=["*"])
+                if len(so_items) > 0:
+                    for item in so_items:   
+                        software_maintenance_items = frappe.new_doc("Software Maintenance Item")
+
+                        if item.start_date is not None:
+                            item.start_date = item.start_date + timedelta(days=365)
+                        if item.end_date is not None:
+                            item.end_date = item.end_date + timedelta(days=365)
+                            if item.start_date is not None and item.end_date is not None:
+                                days_diff = item.end_date - item.start_date
+                                if days_diff == 365:
+                                    item.end_date = item.end_date - timedelta(days=1)
+                        if item.item_type == "Maintenance Item":
+                            item.rate = item.reoccurring_maintenance_amount
+                            item.reoccurring_maintenance_amount = item.reoccurring_maintenance_amount
+                        else:
+                            item.rate = 0
+                            item.reoccurring_maintenance_amount = 0
+
+                        software_maintenance_items.update({
+                            "idx": item.idx,
+                            "item_code": item.item_code,
+                            "item_name": item.item_name,
+                            "description": item.description,
+                            "conversion_factor": item.conversion_factor,
+                            "qty": item.qty,
+                            "rate": item.reoccurring_maintenance_amount,
+                            "reoccurring_maintenance_amount": item.reoccurring_maintenance_amount,
+                            "uom": item.uom,
+                            "item_language": item.item_language,
+                            "delivery_date": frappe.db.get_value("Sales Order", s_m.sales_order, "transaction_date"),
+                            "start_date": item.start_date,
+                            "end_date": item.end_date,
+                            "purchase_price": item.purchase_price,
+                            'parent': s_m.name,
+                            'parentfield': 'items',
+                            'parenttype': "Software Maintenance"
+                        })
+                        software_maintenance_items.insert(ignore_permissions=True)
+                    modified_by = frappe.session.user
+                    # frappe.db.set_value("Software Maintenance", s_m.name, "assign_to", frappe.db.get_value("Sales Order", s_m.sales_order, "assigned_to"), update_modified=False)
+                    frappe.db.set_value("Sales Order", s_m.sales_order, "sales_order_type", "First Sale", update_modified=update_timestamp)
+                    frappe.db.set_value("Sales Order", s_m.sales_order, "software_maintenance", s_m.name, update_modified=update_timestamp)
+                    if update_timestamp:
+                        frappe.db.sql("""update `tabSoftware Maintenance` set `modified` = '{modified}', `modified_by` = '{modified_by}' where `name` = '{sm_name}'""".format(modified= now(), modified_by= modified_by, sm_name=s_m.name))
+                        frappe.db.sql("""update `tabSales Order` set `sales_order_type` = 'Reoccuring Maintenance', `modified` = '{modified}', `modified_by` = '{modified_by}' where `sales_order_type` = 'Follow Up Maintenance' """.format(modified= now(), modified_by= modified_by))
                     else:
-                        item.rate = 0
-                        item.reoccurring_maintenance_amount = 0
-
-                    software_maintenance_items.update({
-                        "idx": item.idx,
-                        "item_code": item.item_code,
-                        "item_name": item.item_name,
-                        "description": item.description,
-                        "conversion_factor": item.conversion_factor,
-                        "qty": item.qty,
-                        "rate": item.reoccurring_maintenance_amount,
-                        "reoccurring_maintenance_amount": item.reoccurring_maintenance_amount,
-                        "uom": item.uom,
-                        "item_language": item.item_language,
-                        "delivery_date": frappe.db.get_value("Sales Order", s_m.sales_order, "transaction_date"),
-                        "start_date": item.start_date,
-                        "end_date": item.end_date,
-                        "purchase_price": item.purchase_price,
-                        'parent': s_m.name,
-                        'parentfield': 'items',
-                        'parenttype': "Software Maintenance"
-                    })
-                    software_maintenance_items.insert(ignore_permissions=True)
-                modified_by = frappe.session.user
-                # frappe.db.set_value("Software Maintenance", s_m.name, "assign_to", frappe.db.get_value("Sales Order", s_m.sales_order, "assigned_to"), update_modified=False)
-                frappe.db.set_value("Sales Order", s_m.sales_order, "sales_order_type", "First Sale", update_modified=update_timestamp)
-                frappe.db.set_value("Sales Order", s_m.sales_order, "software_maintenance", s_m.name, update_modified=update_timestamp)
-                if update_timestamp:
-                    frappe.db.sql("""update `tabSoftware Maintenance` set `modified` = '{modified}', `modified_by` = '{modified_by}' where `name` = '{sm_name}'""".format(modified= now(), modified_by= modified_by, sm_name=s_m.name))
-                    frappe.db.sql("""update `tabSales Order` set `sales_order_type` = 'Reoccuring Maintenance', `modified` = '{modified}', `modified_by` = '{modified_by}' where `sales_order_type` = 'Follow Up Maintenance' """.format(modified= now(), modified_by= modified_by))
-                else:
-                    frappe.db.sql("""update `tabSales Order` set `sales_order_type` = 'Reoccuring Maintenance' where `sales_order_type` = 'Follow Up Maintenance' """)
-                frappe.db.commit()
-            index += 1
-            progress = int( (index / total_rows) * 100)
-            frappe.publish_progress(progress, title='Updating Software Maintenances', description=f'Processing row {index}/{total_rows}')
-        return {"message":"""<h3>The script has run and had updated all Software Maintenance:</h3>
-                <ul>
-                    <li>existing items table have been cleared from all Software Maintenance</li>
-                    <li>the linked Sales Invoice in Software Maintenance has been updated to "First Sale"</li>
-                    <li>the items from that Sales Invoice have been fetched into the Software Maintenance item table</li>
-                    <li>all Sales Orders with sales_order_type "Follow-Up Maintenance have been updated to "Reoccurring Maintenance"</li>
-                </ul>
-                <p>The script has ignored missing date like start/end dates, rates, etc.</p>
-                <p>For further information check in SimpaTec Settings page and consult your project manager.</p> """, "title": "Success"}   
-    except Exception as ex:
-        frappe.db.rollback()
-        frappe.log_error(ex)
-        return {"message":"There was some error occured in the process, Please check error logs.", "title":"Error" }
+                        frappe.db.sql("""update `tabSales Order` set `sales_order_type` = 'Reoccuring Maintenance' where `sales_order_type` = 'Follow Up Maintenance' """)
+                    frappe.db.commit()
+                index += 1
+                progress = int( (index / total_rows) * 100)
+                frappe.publish_progress(progress, title='Updating Software Maintenances', description=f'Processing row {index}/{total_rows}')
+            return {"message":"""<h3>The script has run and had updated all Software Maintenance:</h3>
+                    <ul>
+                        <li>existing items table have been cleared from all Software Maintenance</li>
+                        <li>the linked Sales Invoice in Software Maintenance has been updated to "First Sale"</li>
+                        <li>the items from that Sales Invoice have been fetched into the Software Maintenance item table</li>
+                        <li>all Sales Orders with sales_order_type "Follow-Up Maintenance have been updated to "Reoccurring Maintenance"</li>
+                    </ul>
+                    <p>The script has ignored missing date like start/end dates, rates, etc.</p>
+                    <p>For further information check in SimpaTec Settings page and consult your project manager.</p> """, "title": "Success"}   
+        except Exception as ex:
+            frappe.db.rollback()
+            frappe.log_error(ex)
+            return {"message":"There was some error occured in the process, Please check error logs.", "title":"Error" }

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
@@ -14,31 +14,87 @@ class SimpaTecSettings(Document):
             # Update item descriptions data from old field id_xx to new field item_description_xx
             
             # SOFTWARE MAINTENANCE ITEM
+            # UPDATE DESCRIPTIONS
             frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `id_en`, `item_description_fr` = `id_fr`,`item_description_de` = `id_de`")
-                
+            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `description` where item_description_en is null;")
+            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_fr` = `description` where item_description_fr is null;")
+            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_de` = `description` where item_description_de is null;")
+            
+            # UPDATE ITEM NAMES
+            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_name_en` = `item_name` where item_name_en is null;")
+            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_name_de` = `item_name` where item_name_de is null;")
+            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_name_fr` = `item_name` where item_name_fr is null;")
+            
+            
             # SALES ORDER ITEM
+            # UPDATE DESCRIPTIONS
             if frappe.db.exists("Custom Field", "Sales Order Item-id_en"):
                 frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `id_en`")
+                frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `description` where item_description_en is null;")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_en", force=1)
             if frappe.db.exists("Custom Field", "Sales Order Item-id_fr"):
                 frappe.db.sql("update `tabSales Order Item` set `item_description_fr` = `id_fr`")
+                frappe.db.sql("update `tabSales Order Item` set `item_description_fr` = `description` where item_description_fr is null;")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_fr", force=1)
             if frappe.db.exists("Custom Field", "Sales Order Item-id_de"):
                 frappe.db.sql("update `tabSales Order Item` set `item_description_de` = `id_de`")
+                frappe.db.sql("update `tabSales Order Item` set `item_description_de` = `description` where item_description_de is null;")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_de", force=1)
+            
+            # UPDATE ITEM NAMES
+            if frappe.db.exists("Custom Field", "Sales Order Item-item_name_en"):
+                frappe.db.sql("update `tabSales Order Item` set `item_name_en` = `item_name` where item_name_en is null;")
                 
+            if frappe.db.exists("Custom Field", "Sales Order Item-item_name_de"):
+                frappe.db.sql("update `tabSales Order Item` set `item_name_de` = `item_name` where item_name_de is null;")
+
+            if frappe.db.exists("Custom Field", "Sales Order Item-item_name_fr"):
+                frappe.db.sql("update `tabSales Order Item` set `item_name_fr` = `item_name` where item_name_fr is null;")
+
+
 
             # QUOTATION ITEM
+            # UPDATE DESCRIPTIONS
             if frappe.db.exists("Custom Field", "Quotation Item-id_en"):
                 frappe.db.sql("update `tabQuotation Item` set `item_description_en` = `id_en`")
+                frappe.db.sql("update `tabQuotation Item` set `item_description_en` = `description` where item_description_de is null;")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_en", force=1)
             if frappe.db.exists("Custom Field", "Quotation Item-id_fr"):
                 frappe.db.sql("update `tabQuotation Item` set `item_description_fr` = `id_fr`")
+                frappe.db.sql("update `tabQuotation Item` set `item_description_fr` = `description` where item_description_fr is null;")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_fr", force=1)
             if frappe.db.exists("Custom Field", "Quotation Item-id_de"):
                 frappe.db.sql("update `tabQuotation Item` set `item_description_de` = `id_de`")
+                frappe.db.sql("update `tabQuotation Item` set `item_description_de` = `description` where item_description_de is null;")
                 # frappe.delete_doc("Custom Field", "Quotation Item-id_fr", force=1)
             
+            # UPDATE ITEM NAMES
+            if frappe.db.exists("Custom Field", "Quotation Item-item_name_en"):
+                frappe.db.sql("update `tabQuotation Item` set `item_name_en` = `item_name` where item_name_en is null;")
+                
+            if frappe.db.exists("Custom Field", "Quotation Item-item_name_de"):
+                frappe.db.sql("update `tabQuotation Item` set `item_name_de` = `item_name` where item_name_de is null;")
+
+            if frappe.db.exists("Custom Field", "Quotation Item-item_name_fr"):
+                frappe.db.sql("update `tabQuotation Item` set `item_name_fr` = `item_name` where item_name_fr is null;")
+
+            # PURCHASE ORDER ITEM
+            # UPDATE DESCRIPTIONS
+            if frappe.db.exists("Custom Field", "Purchase Order Item-item_description_en"):
+                frappe.db.sql("update `tabPurchase Order Item` set `item_description_en` = `description` where item_description_en is null;")
+            if frappe.db.exists("Custom Field", "Purchase Order Item-item_description_de"):
+                frappe.db.sql("update `tabPurchase Order Item` set `item_description_de` = `description` where item_description_de is null;")
+            if frappe.db.exists("Custom Field", "Purchase Order Item-item_description_fr"):
+                frappe.db.sql("update `tabPurchase Order Item` set `item_description_fr` = `description` where item_description_fr is null;")
+                
+            # UPDATE ITEM NAMES
+            if frappe.db.exists("Custom Field", "Purchase Order Item-item_name_en"):
+                frappe.db.sql("update `tabPurchase Order Item` set `item_name_en` = `item_name` where item_name_en is null;")
+            if frappe.db.exists("Custom Field", "Purchase Order Item-item_name_de"):
+                frappe.db.sql("update `tabPurchase Order Item` set `item_name_de` = `item_name` where item_name_de is null;")
+            if frappe.db.exists("Custom Field", "Purchase Order Item-item_name_fr"):
+                frappe.db.sql("update `tabPurchase Order Item` set `item_name_fr` = `item_name` where item_name_fr is null;")
+                
             modified_by = frappe.session.user
             update_timestamp = int(self.update_timestamp)
             
@@ -46,10 +102,12 @@ class SimpaTecSettings(Document):
                 frappe.db.sql("""update `tabSoftware Maintenance` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2""".format(modified= now(), modified_by= modified_by))
                 frappe.db.sql("""update `tabSales Order` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2 """.format(modified= now(), modified_by= modified_by))
                 frappe.db.sql("""update `tabQuotation` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2 """.format(modified= now(), modified_by= modified_by))
+                frappe.db.sql("""update `tabPurchase Order` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2 """.format(modified= now(), modified_by= modified_by))
                 
-            return {"message":"""<h3>The script has run and had updated all Item Descriptions in Software Maintenance, Sales Order and Quotation:</h3>
+            return {"message":"""<h3>The script has run and had updated all Item Name and Item Descriptions in Software Maintenance, Sales Order, Quotation and Purchase Order:</h3>
                     <ul>
                         <li>Copied the old item description data from id_xx field to item_description_xx</li>
+                        <li>Copied the old item_name data from item_name field to item_name_xx/li>
                     </ul>
                     <p>For further information check in SimpaTec Settings page and consult your project manager.</p> """, "title": "Success"}   
         except Exception as ex:

--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -76,11 +76,11 @@
    "fetch_if_empty": 1,
    "fieldname": "id_en",
    "fieldtype": "Text Editor",
+   "hidden": 1,
    "label": "Description EN",
    "oldfieldname": "description",
    "oldfieldtype": "Small Text",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -104,11 +104,11 @@
    "fetch_if_empty": 1,
    "fieldname": "id_de",
    "fieldtype": "Text Editor",
+   "hidden": 1,
    "label": "Description DE",
    "oldfieldname": "description",
    "oldfieldtype": "Small Text",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -132,11 +132,11 @@
    "fetch_if_empty": 1,
    "fieldname": "id_fr",
    "fieldtype": "Text Editor",
+   "hidden": 1,
    "label": "Description FR",
    "oldfieldname": "description",
    "oldfieldtype": "Small Text",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -326,15 +326,13 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-07-26 19:53:51.607232",
+ "modified": "2024-07-30 15:51:14.285139",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Software Maintenance Item",
- "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
# Migration Required
## Gitlab Issue [#96](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/96)
### Points covered in this PR
- Created a script that will copy the old id_xx data into item_description_xx
- Copy description into item_description_xx if it's empty.
- Copy Item name into Item Name XX 
- Script will run from Simpatec Settings
  <img width="1330" alt="Screenshot 2024-07-30 at 17 57 34" src="https://github.com/user-attachments/assets/a2b6128e-7c8f-4d63-a655-b2b5ec86c8f7">
- Sales Order Items, Quotation Items, Purchase Order Items and Software Maintenance Item will update on this script
- Refactored the update_software_maintenance_items function.
- Hide the id_xx field for now. Will remove after confirmation of not loosing any data

### Preview:
![recording-item_desc_update](https://github.com/user-attachments/assets/7618ba0c-afb8-4316-9a24-a71d538b9c48)

