### PR TITLE
Removed default values

### DIFF
--- a/simpatec/public/js/quotation.js
+++ b/simpatec/public/js/quotation.js
@@ -78,21 +78,18 @@ frappe.ui.form.on('Quotation', {
 						fieldname: "party_name",
 						fieldtype: "Link",
 						options: "Customer",
-						default: frm.doc.party_name || undefined
 					},
 					{
 						label: "Quotation Label",
 						fieldname: "quotation_label",
 						fieldtype: "Link",
 						options: "Angebotsvorlage",
-						default: frm.doc.quotation_label || undefined
 					},
 					{
 						label: "Item Group",
 						fieldname: "item_group",
 						fieldtype: "Link",
 						options: "Item Group",
-						default: frm.doc.item_group || undefined
 					},
 
 				],


### PR DESCRIPTION
# Gitlab Issue [#73](https://git.phamos.eu/simpatec/P-0142Marketing/-/work_items/73)
## Points covered in this PR
- Removed default values in the Get item from Quotation popup.
### Before
![recording-remove_default_values_before](https://github.com/user-attachments/assets/e1306429-b388-4435-b014-7627cf8d3eb8)
### After
- ![recording-remove_default_values](https://github.com/user-attachments/assets/e88fc26b-11b0-4cae-bf07-f353c6d1cdc3)
