### PR TITLE
Item description bug Fixed

### DIFF
--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.js
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.js
@@ -16,7 +16,7 @@ frappe.ui.form.on('SimpaTec Settings', {
 			}
 		})
 	},
-	update_item_fieds: function(frm){
+	update_item_fields: function(frm){
 		frm.call({
 			method: "update_item_details",
 			doc: frm.doc,

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.json
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.json
@@ -17,7 +17,7 @@
   "update_timestamp",
   "html_2",
   "html_4",
-  "update_item_fieds"
+  "update_item_fields"
  ],
  "fields": [
   {
@@ -77,20 +77,20 @@
    "label": "Software Maintenance"
   },
   {
-   "fieldname": "update_item_fieds",
-   "fieldtype": "Button",
-   "label": "Update Item Fieds"
-  },
-  {
    "fieldname": "html_4",
    "fieldtype": "HTML",
    "options": "<p style=\"color: red;\">Careful: Clicking this button will execute a script that transfers data from old fields to new fields and makes significant alterations to the field contents, potentially causing irreversible changes. Please consult higher management before proceeding with this action.</p>\n"
+  },
+  {
+   "fieldname": "update_item_fields",
+   "fieldtype": "Button",
+   "label": "Apply Changes to Item Fields"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-07-30 13:24:07.745835",
+ "modified": "2024-08-19 13:38:48.000138",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "SimpaTec Settings",

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
@@ -29,16 +29,66 @@ class SimpaTecSettings(Document):
             # SALES ORDER ITEM
             # UPDATE DESCRIPTIONS
             if frappe.db.exists("Custom Field", "Sales Order Item-id_en"):
-                frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `id_en`")
-                frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `description` where item_description_en is null;")
+                # frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `id_en`")
+                # frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `description` where item_description_en is null;")
+                frappe.db.sql("""UPDATE `tabSales Order Item`
+                                    SET `item_description_en` = 
+                                        CASE
+                                            -- If `item_description_en` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_en` IS NULL 
+                                                OR `item_description_en` = ''	
+                                                OR `item_description_en` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_en` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_en` IS NULL 
+                                                        OR `id_en` = '' 
+                                                        OR `id_en` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_en` also doesn't have valid content, use `description`
+                                                    ELSE `id_en` -- Otherwise, use `id_en`
+                                                END
+                                            ELSE `item_description_en` -- If `item_description_en` does not match the conditions, do nothing
+                                        END""")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_en", force=1)
             if frappe.db.exists("Custom Field", "Sales Order Item-id_fr"):
-                frappe.db.sql("update `tabSales Order Item` set `item_description_fr` = `id_fr`")
-                frappe.db.sql("update `tabSales Order Item` set `item_description_fr` = `description` where item_description_fr is null;")
+                frappe.db.sql("""UPDATE `tabSales Order Item`
+                                    SET `item_description_fr` = 
+                                        CASE
+                                            -- If `item_description_fr` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_fr` IS NULL 
+                                                OR `item_description_fr` = ''	
+                                                OR `item_description_fr` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_fr` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_fr` IS NULL 
+                                                        OR `id_fr` = '' 
+                                                        OR `id_fr` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_fr` also doesn't have valid content, use `description`
+                                                    ELSE `id_fr` -- Otherwise, use `id_fr`
+                                                END
+                                            ELSE `item_description_fr` -- If `item_description_fr` does not match the conditions, do nothing
+                                        END""")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_fr", force=1)
             if frappe.db.exists("Custom Field", "Sales Order Item-id_de"):
-                frappe.db.sql("update `tabSales Order Item` set `item_description_de` = `id_de`")
-                frappe.db.sql("update `tabSales Order Item` set `item_description_de` = `description` where item_description_de is null;")
+                frappe.db.sql("""UPDATE `tabSales Order Item`
+                                    SET `item_description_de` = 
+                                        CASE
+                                            -- If `item_description_de` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_de` IS NULL 
+                                                OR `item_description_de` = ''	
+                                                OR `item_description_de` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_de` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_de` IS NULL 
+                                                        OR `id_de` = '' 
+                                                        OR `id_de` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_de` also doesn't have valid content, use `description`
+                                                    ELSE `id_de` -- Otherwise, use `id_de`
+                                                END
+                                            ELSE `item_description_de` -- If `item_description_de` does not match the conditions, do nothing
+                                        END""")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_de", force=1)
             
             # UPDATE ITEM NAMES
@@ -56,16 +106,67 @@ class SimpaTecSettings(Document):
             # QUOTATION ITEM
             # UPDATE DESCRIPTIONS
             if frappe.db.exists("Custom Field", "Quotation Item-id_en"):
-                frappe.db.sql("update `tabQuotation Item` set `item_description_en` = `id_en`")
-                frappe.db.sql("update `tabQuotation Item` set `item_description_en` = `description` where item_description_de is null;")
+                
+                frappe.db.sql("""UPDATE `tabQuotation Item`
+                                    SET `item_description_en` = 
+                                        CASE
+                                            -- If `item_description_en` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_en` IS NULL 
+                                                OR `item_description_en` = ''	
+                                                OR `item_description_en` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_en` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_en` IS NULL 
+                                                        OR `id_en` = '' 
+                                                        OR `id_en` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_en` also doesn't have valid content, use `description`
+                                                    ELSE `id_en` -- Otherwise, use `id_en`
+                                                END
+                                            ELSE `item_description_en` -- If `item_description_en` does not match the conditions, do nothing
+                                        END""")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_en", force=1)
             if frappe.db.exists("Custom Field", "Quotation Item-id_fr"):
-                frappe.db.sql("update `tabQuotation Item` set `item_description_fr` = `id_fr`")
-                frappe.db.sql("update `tabQuotation Item` set `item_description_fr` = `description` where item_description_fr is null;")
+                
+                frappe.db.sql("""UPDATE `tabQuotation Item`
+                                    SET `item_description_fr` = 
+                                        CASE
+                                            -- If `item_description_fr` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_fr` IS NULL 
+                                                OR `item_description_fr` = ''	
+                                                OR `item_description_fr` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_fr` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_fr` IS NULL 
+                                                        OR `id_fr` = '' 
+                                                        OR `id_fr` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_fr` also doesn't have valid content, use `description`
+                                                    ELSE `id_fr` -- Otherwise, use `id_fr`
+                                                END
+                                            ELSE `item_description_fr` -- If `item_description_fr` does not match the conditions, do nothing
+                                        END""")
                 # frappe.delete_doc("Custom Field", "Sales Order Item-id_fr", force=1)
             if frappe.db.exists("Custom Field", "Quotation Item-id_de"):
-                frappe.db.sql("update `tabQuotation Item` set `item_description_de` = `id_de`")
-                frappe.db.sql("update `tabQuotation Item` set `item_description_de` = `description` where item_description_de is null;")
+                
+                frappe.db.sql("""UPDATE `tabQuotation Item`
+                                    SET `item_description_de` = 
+                                        CASE
+                                            -- If `item_description_de` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_de` IS NULL 
+                                                OR `item_description_de` = ''	
+                                                OR `item_description_de` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_de` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_de` IS NULL 
+                                                        OR `id_de` = '' 
+                                                        OR `id_de` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_de` also doesn't have valid content, use `description`
+                                                    ELSE `id_de` -- Otherwise, use `id_de`
+                                                END
+                                            ELSE `item_description_de` -- If `item_description_de` does not match the conditions, do nothing
+                                        END""")
                 # frappe.delete_doc("Custom Field", "Quotation Item-id_fr", force=1)
             
             # UPDATE ITEM NAMES
@@ -81,11 +182,19 @@ class SimpaTecSettings(Document):
             # PURCHASE ORDER ITEM
             # UPDATE DESCRIPTIONS
             if frappe.db.exists("Custom Field", "Purchase Order Item-item_description_en"):
-                frappe.db.sql("update `tabPurchase Order Item` set `item_description_en` = `description` where item_description_en is null;")
+                frappe.db.sql("""update `tabPurchase Order Item` set `item_description_en` = `description` 
+                              where 
+                              `item_description_en` IS NULL 
+                                OR `item_description_en` = ''
+                                OR `item_description_en` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%';""")
             if frappe.db.exists("Custom Field", "Purchase Order Item-item_description_de"):
-                frappe.db.sql("update `tabPurchase Order Item` set `item_description_de` = `description` where item_description_de is null;")
+                frappe.db.sql("""update `tabPurchase Order Item` set `item_description_de` = `description` where `item_description_de` IS NULL 
+                                                OR `item_description_de` = ''	
+                                                OR `item_description_de` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%';""")
             if frappe.db.exists("Custom Field", "Purchase Order Item-item_description_fr"):
-                frappe.db.sql("update `tabPurchase Order Item` set `item_description_fr` = `description` where item_description_fr is null;")
+                frappe.db.sql("""update `tabPurchase Order Item` set `item_description_fr` = `description` where `item_description_fr` IS NULL 
+                                                OR `item_description_fr` = ''	
+                                                OR `item_description_fr` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%';""")
                 
             # UPDATE ITEM NAMES
             if frappe.db.exists("Custom Field", "Purchase Order Item-item_name_en"):
@@ -103,11 +212,11 @@ class SimpaTecSettings(Document):
                 frappe.db.sql("""update `tabSales Order` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2 """.format(modified= now(), modified_by= modified_by))
                 frappe.db.sql("""update `tabQuotation` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2 """.format(modified= now(), modified_by= modified_by))
                 frappe.db.sql("""update `tabPurchase Order` set `modified` = '{modified}', `modified_by` = '{modified_by}' where docstatus != 2 """.format(modified= now(), modified_by= modified_by))
-                
+            frappe.db.commit()
             return {"message":"""<h3>The script has run and had updated all Item Name and Item Descriptions in Software Maintenance, Sales Order, Quotation and Purchase Order:</h3>
                     <ul>
                         <li>Copied the old item description data from id_xx field to item_description_xx</li>
-                        <li>Copied the old item_name data from item_name field to item_name_xx/li>
+                        <li>Copied the old item_name data from item_name field to item_name_xx</li>
                     </ul>
                     <p>For further information check in SimpaTec Settings page and consult your project manager.</p> """, "title": "Success"}   
         except Exception as ex:

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
@@ -15,10 +15,65 @@ class SimpaTecSettings(Document):
             
             # SOFTWARE MAINTENANCE ITEM
             # UPDATE DESCRIPTIONS
-            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `id_en`, `item_description_fr` = `id_fr`,`item_description_de` = `id_de`")
-            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `description` where item_description_en is null;")
-            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_fr` = `description` where item_description_fr is null;")
-            frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_de` = `description` where item_description_de is null;")
+            # frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `id_en`, `item_description_fr` = `id_fr`,`item_description_de` = `id_de`")
+            # frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `description` where item_description_en is null;")
+            # frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_fr` = `description` where item_description_fr is null;")
+            # frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_de` = `description` where item_description_de is null;")
+            frappe.db.sql("""UPDATE `tabSoftware Maintenance Item`
+                                    SET `item_description_en` = 
+                                        CASE
+                                            -- If `item_description_en` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_en` IS NULL 
+                                                OR `item_description_en` = ''	
+                                                OR `item_description_en` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_en` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_en` IS NULL 
+                                                        OR `id_en` = '' 
+                                                        OR `id_en` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_en` also doesn't have valid content, use `description`
+                                                    ELSE `id_en` -- Otherwise, use `id_en`
+                                                END
+                                            ELSE `item_description_en` -- If `item_description_en` does not match the conditions, do nothing
+                                        END""")
+            frappe.db.sql("""UPDATE `tabSoftware Maintenance Item`
+                                    SET `item_description_fr` = 
+                                        CASE
+                                            -- If `item_description_fr` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_fr` IS NULL 
+                                                OR `item_description_fr` = ''	
+                                                OR `item_description_fr` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_fr` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_fr` IS NULL 
+                                                        OR `id_fr` = '' 
+                                                        OR `id_fr` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_fr` also doesn't have valid content, use `description`
+                                                    ELSE `id_fr` -- Otherwise, use `id_fr`
+                                                END
+                                            ELSE `item_description_fr` -- If `item_description_fr` does not match the conditions, do nothing
+                                        END""")
+            
+            frappe.db.sql("""UPDATE `tabSoftware Maintenance Item`
+                                    SET `item_description_de` = 
+                                        CASE
+                                            -- If `item_description_de` is null, empty, or contains the specific HTML pattern
+                                            WHEN `item_description_de` IS NULL 
+                                                OR `item_description_de` = ''	
+                                                OR `item_description_de` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                            THEN 
+                                                -- If `id_de` is null, empty, or contains the specific HTML pattern
+                                                CASE 
+                                                    WHEN `id_de` IS NULL 
+                                                        OR `id_de` = '' 
+                                                        OR `id_de` LIKE '%<div class="ql-editor read-mode"><p><br></p></div>%'
+                                                    THEN `description` -- If `id_de` also doesn't have valid content, use `description`
+                                                    ELSE `id_de` -- Otherwise, use `id_de`
+                                                END
+                                            ELSE `item_description_de` -- If `item_description_de` does not match the conditions, do nothing
+                                        END""")
             
             # UPDATE ITEM NAMES
             frappe.db.sql("update `tabSoftware Maintenance Item` set `item_name_en` = `item_name` where item_name_en is null;")

--- a/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
+++ b/simpatec/simpatec/doctype/simpatec_settings/simpatec_settings.py
@@ -15,10 +15,6 @@ class SimpaTecSettings(Document):
             
             # SOFTWARE MAINTENANCE ITEM
             # UPDATE DESCRIPTIONS
-            # frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `id_en`, `item_description_fr` = `id_fr`,`item_description_de` = `id_de`")
-            # frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_en` = `description` where item_description_en is null;")
-            # frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_fr` = `description` where item_description_fr is null;")
-            # frappe.db.sql("update `tabSoftware Maintenance Item` set `item_description_de` = `description` where item_description_de is null;")
             frappe.db.sql("""UPDATE `tabSoftware Maintenance Item`
                                     SET `item_description_en` = 
                                         CASE
@@ -84,8 +80,6 @@ class SimpaTecSettings(Document):
             # SALES ORDER ITEM
             # UPDATE DESCRIPTIONS
             if frappe.db.exists("Custom Field", "Sales Order Item-id_en"):
-                # frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `id_en`")
-                # frappe.db.sql("update `tabSales Order Item` set `item_description_en` = `description` where item_description_en is null;")
                 frappe.db.sql("""UPDATE `tabSales Order Item`
                                     SET `item_description_en` = 
                                         CASE


### PR DESCRIPTION
# Migration Required
## Gitlab Issue [#100](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/89?work_item_iid=100)
### Points covered in this PR

- Renamed Button in Simpatec Settings which will trigger the item descriptions update script
   <img width="484" alt="image" src="https://github.com/user-attachments/assets/37e3d090-7b12-4450-a9f2-4f5221c42be1">

## Cases tested
These case has been tested on local environment.
### Check item_description_en/de/fr:
  - If **item_description_en/de/fr** is empty, null, or contains a specific empty HTML pattern (like a placeholder), then do the following:
- Check id_en:
  - If **id_en/de/fr** is also empty, null, or contains the same specific empty HTML pattern, then use description.
     <img width="675" alt="image" src="https://github.com/user-attachments/assets/98c2ea1d-98a1-44c4-aebd-6121f31540c3">
  - Otherwise, use the value from **id_en/de/fr**.
     <img width="654" alt="image" src="https://github.com/user-attachments/assets/f8c81cd3-0a5b-47ff-9d39-ae9e0bc41ec3">
- If **item_description_en/de/fr** is not empty, not null, and does not contain the specific empty HTML pattern, keep its current value.
   <img width="666" alt="image" src="https://github.com/user-attachments/assets/c06f83d7-9b08-4267-aec2-7ded2a92dcae">
