### PR TITLE
fix: removing reqd on description and item name fields Update software_maintenance_item.json

### DIFF
--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -67,7 +67,6 @@
    "oldfieldtype": "Data",
    "print_hide": 1,
    "print_width": "150",
-   "reqd": 1,
    "width": "150"
   },
   {
@@ -95,7 +94,6 @@
    "oldfieldtype": "Data",
    "print_hide": 1,
    "print_width": "150",
-   "reqd": 1,
    "width": "150"
   },
   {
@@ -123,7 +121,6 @@
    "oldfieldtype": "Data",
    "print_hide": 1,
    "print_width": "150",
-   "reqd": 1,
    "width": "150"
   },
   {
@@ -264,7 +261,6 @@
    "label": "Item Name",
    "print_hide": 1,
    "print_width": "150",
-   "reqd": 1,
    "width": "150"
   },
   {
@@ -275,7 +271,6 @@
    "fieldtype": "Text Editor",
    "label": "Description EN",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -286,7 +281,6 @@
    "fieldtype": "Text Editor",
    "label": "Description DE",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -297,7 +291,6 @@
    "fieldtype": "Text Editor",
    "label": "Description FR",
    "print_width": "300",
-   "reqd": 1,
    "width": "300"
   },
   {
@@ -320,7 +313,6 @@
    "fieldtype": "Text Editor",
    "label": "Description",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   }
  ],

--- a/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
+++ b/simpatec/simpatec/doctype/software_maintenance_item/software_maintenance_item.json
@@ -318,7 +318,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-07-30 15:51:14.285139",
+ "modified": "2024-08-22 07:51:14.285139",
  "modified_by": "Administrator",
  "module": "Simpatec",
  "name": "Software Maintenance Item",


### PR DESCRIPTION
for the customer to carry on work although only manually we are removing the mandatory option on item_name_ and item_description_ fields till the script works to fill the empty fields automatically.