### PR TITLE
Alert Message changed

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -119,10 +119,7 @@ def update_software_maintenance(doc, method=None):
 			item_start_date = item.start_date
 			item_end_date = item.end_date
 
-			if doc.sales_order_type == "Reoccuring Maintenance":
-				item_start_date = software_maintenance.performance_period_start
-				item_end_date = software_maintenance.performance_period_end
-
+			
 			if item.item_type == "Maintenance Item":
 				item_rate = item.reoccurring_maintenance_amount
 			else:
@@ -135,7 +132,11 @@ def update_software_maintenance(doc, method=None):
 				item_end_date = datetime.strptime(item_end_date, "%Y-%m-%d").date()
 			item_start_date = item_start_date + timedelta(days=365)
 			item_end_date = item_end_date + timedelta(days=365)
-			if doc.sales_order_type == "Follow-Up Sale":
+
+			if doc.sales_order_type == "Reoccuring Maintenance":
+				item_start_date = software_maintenance.performance_period_start
+				item_end_date = software_maintenance.performance_period_end
+			elif doc.sales_order_type == "Follow-Up Sale":
 				item_end_date = software_maintenance.performance_period_end + timedelta(days=365)
 				
 				# Initialize a counter for months

--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -490,8 +490,8 @@ def validate_maintenance_amount(doc):
 		row = []
 		for item in doc.items:
 			if item.reoccurring_maintenance_amount <= 0 and item.item_type == "Maintenance Item":
-				row.append(f"<li>Row {item.idx}</li>")
+				row.append(_(f"<li>{_('Row')} {item.idx}</li>"))
 		if len(row) > 0:
 			row = "".join(row)
-			msg = f"One or more maintenance items in the Sales Order Item table have an amount that is less than or equal to 0.00. Please review these items to ensure this is correct.<ul >{row}</ul>"
-			frappe.msgprint(msg, title="Warning: Invalid Maintenance Amount")
+			msg = f"{_('One or more maintenance items in the Sales Order Item table have an amount that is less than or equal to 0.00. Please review these items to ensure this is correct.')} <ul >{row}</ul>"
+			frappe.msgprint(msg, title=_("Warning: Invalid Maintenance Amount"))

--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -486,11 +486,12 @@ def set_delivery_date(items, sales_order):
 
 @frappe.whitelist()
 def validate_maintenance_amount(doc):
-	row = []
-	for item in doc.items:
-		if item.reoccurring_maintenance_amount <= 0 and item.item_type == "Maintenance Item":
-			row.append(f"<li>Row {item.idx}</li>")
-	if len(row) > 0:
-		row = "".join(row)
-		msg = f"The maintenance amount cannot be zero or less. Please review and correct the maintenance prices in the following rows:<ul >{row}</ul>"
-		frappe.msgprint(msg, title="Error: Invalid Maintenance Amount")
+	if doc.docstatus == 0:
+		row = []
+		for item in doc.items:
+			if item.reoccurring_maintenance_amount <= 0 and item.item_type == "Maintenance Item":
+				row.append(f"<li>Row {item.idx}</li>")
+		if len(row) > 0:
+			row = "".join(row)
+			msg = f"One or more maintenance items in the Sales Order Item table have an amount that is less than or equal to 0.00. Please review these items to ensure this is correct.<ul >{row}</ul>"
+			frappe.msgprint(msg, title="Warning: Invalid Maintenance Amount")

--- a/simpatec/translations/de.csv
+++ b/simpatec/translations/de.csv
@@ -1,0 +1,3 @@
+Row,Reihe
+Warning: Invalid Maintenance Amount,Achtung: Ungültiger Unterhaltsbetrag
+One or more maintenance items in the Sales Order Item table have an amount that is less than or equal to 0.00. Please review these items to ensure this is correct.,"Ein oder mehrere Wartungsartikel in der Tabelle „Verkaufsauftragsartikel“ weisen einen Betrag auf, der kleiner oder gleich 0,00 ist. Bitte überprüfen Sie diese Artikel, um sicherzustellen, dass dies korrekt ist."

--- a/simpatec/translations/de.csv
+++ b/simpatec/translations/de.csv
@@ -1,3 +1,0 @@
-Row,Reihe
-Warning: Invalid Maintenance Amount,Achtung: Ungültiger Unterhaltsbetrag
-One or more maintenance items in the Sales Order Item table have an amount that is less than or equal to 0.00. Please review these items to ensure this is correct.,"Ein oder mehrere Wartungsartikel in der Tabelle „Verkaufsauftragsartikel“ weisen einen Betrag auf, der kleiner oder gleich 0,00 ist. Bitte überprüfen Sie diese Artikel, um sicherzustellen, dass dies korrekt ist."


### PR DESCRIPTION
## Gitlab Issue [#103](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/57?work_item_iid=103)
### Points covered in this PR
- Message on condition reoccurring maintenance amount <= 0 will be only shown on draft mode of the document
- Alert Message changed
  <img width="1311" alt="Screenshot 2024-08-27 at 08 31 02" src="https://github.com/user-attachments/assets/281820c7-1eee-4a38-968d-60bce1ee9498">
- Added Translation functionality.
  DEMO: <img width="1313" alt="Screenshot 2024-08-27 at 08 56 20" src="https://github.com/user-attachments/assets/465a549f-cfc4-4392-90ef-1ecd5ca9ccc9">

