### PR TITLE
P0014 153 quotation doctype enhancements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+## **Pull Request Description Template:**
+
+Use Markdown for formatting.
+
+**Markdown**
+
+\`## Description
+
+\[Clearly and concisely describe the changes introduced by this pull request. Explain the "why" behind the changes and the approach taken. Provide context where necessary.\]
+
+**Key changes:**
+
+* \[List the most important changes made. Be specific. Use bullet points or numbered lists.\]
+* \[Example: Implemented two-factor authentication using TOTP.\]
+* \[Example: Fixed a bug where dates were displayed in the wrong format in the user profile section.\]
+* \[Example: Added a new setting to allow users to switch between light and dark mode.\]
+
+**Related issue(s)/ticket(s):**
+
+* \[Link to any related issues or tickets. Use keywords like "Fixes," "Resolves," "Closes," or "Relates to."\]
+* \[The link preferably should be a link to a GitLab issue. If possible, also add a link to the Mattermost thread. The important thing is to have enough context to review the Pull Request.\]
+* \[Example: GitLab Issue ]
+* \[Example: Mattermost Thread ]
+* \[Example: Fixes #123, Closes #456\]
+
+**Testing done:**
+
+* \[Describe the testing performed to ensure the changes are working as expected. Be specific about the test cases and scenarios covered.\]
+* \[Example: Manually tested login with two-factor authentication enabled and disabled.\]
+* \[Example: Ran unit tests and integration tests for the date formatting functionality.\]
+* \[Example: Tested dark mode on Chrome, Firefox, and Safari.\]
+
+**Screenshots & GIFs (if applicable):**
+
+* \[Include screenshots to visually demonstrate the changes, especially for UI changes.\]
+* \[The screenshot should be marked with highlighters, rectangles, arrows, or any form of visual representation to focus on the area of the image that matters.\]
+* \[Make sure not to include any screenshots that show real customer data, for example: addresses, names, numbers, etc.\]
+* \[Include GIFs to understand the workflow and process better.\]
+
+**Further comments/notes (optional):**
+
+* \[Add any additional information that might be helpful for reviewers. This could include potential edge cases, limitations, or alternative approaches considered.\]
+* \[Example: Considered using SMS-based authentication but decided to go with TOTP for better security.\]
+
+**Checklist:**
+
+* [ ] I have performed a self-review of my code.
+* [ ] I have added or updated unit tests.
+* [ ] I have updated the documentation (if necessary).
+* [ ] I have followed the project's coding style guidelines.

--- a/simpatec/fixtures/property_setter.json
+++ b/simpatec/fixtures/property_setter.json
@@ -62,5 +62,39 @@
   "property_type": "Check",
   "row_name": null,
   "value": "1"
+ },
+ {
+  "default_value": null,
+  "doc_type": "Quotation",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "customer_address",
+  "modified": "2025-03-05 04:12:51.671763",
+  "name": "Quotation-customer_address-fetch_from",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "property": "fetch_from",
+  "property_type": "Small Text",
+  "row_name": null,
+  "value": "customer_subsidiary.billing_address"
+ },
+ {
+  "default_value": null,
+  "doc_type": "Quotation",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "customer_address",
+  "modified": "2025-03-05 04:15:11.320777",
+  "name": "Quotation-customer_address-description",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "property": "description",
+  "property_type": "Text",
+  "row_name": null,
+  "value": "This address is the Subsidiary Address fetched from the Customer Subsidiary."
  }
 ]

--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -236,7 +236,9 @@ fixtures = [
 					"Sales Order-payment_terms_template-fetch_from",
                     "Quotation-payment_terms_template-fetch_from",
 					"Sales Invoice-payment_terms_template-fetch_from",
-                    "Sales Order-software_maintenance-no_copy"
+                    "Sales Order-software_maintenance-no_copy",
+                    "Quotation-customer_address-fetch_from",
+                    "Quotation-customer_address-description"
 				)
 			]
 		]

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -640,57 +640,73 @@ def get_custom_fields():
 	]
  	
 	custom_fields_quo = [
-     	{
-			"label": "Customer Subsidiary",
-			"fieldname": "customer_subsidiary",
-			"fieldtype": "Link",
-			"options": "Customer Subsidiary",
-			"insert_after": "party_name",
-		},
+		
 		{
 			"label": "SimpaTec",
 			"fieldname": "simpatec_section",
 			"fieldtype": "Section Break",
 		},	
-		{
-			"label": "Sales Order Type",
-			"fieldname": "sales_order_type",
-			"fieldtype": "Select",
-			"options": "\nFirst Sale\nFollow-Up Sale\nReoccuring Maintenance\nRTO\nSubscription Annual\nInternal Clearance\nOther",
-			"default": "",
-			"insert_after": "simpatec_section"
+     	{
+			"label": "Customer Subsidiary",
+			"fieldname": "customer_subsidiary",
+			"fieldtype": "Link",
+			"options": "Customer Subsidiary",
+			"insert_after": "simpatec_section",
 		},
 		{
-			"label": "Item Group",
-			"fieldname": "item_group",
+			"label": "Subsidiary Address",
+			"fieldname": "subsidiary_address",
 			"fieldtype": "Link",
-			"options": "Item Group",
-			"insert_after": "sales_order_type"
+   			"options": "Address",
+			"fetch_from": "customer_subsidiary.subsidiary_address",
+      		"description": "This address will be fetched from the linked Customer Subsidiary and is the main address throughout the sales process.\nERPNext's standard address fields will be used for billing and shipping only.",
+			"fetch_if_empty": 1,
+   			"insert_after": "customer_subsidiary"
 		},
 		{
 			"label": "Quotation Label",
 			"fieldname": "quotation_label",
 			"fieldtype": "Link",
 			"options": "Angebotsvorlage",
-			"insert_after": "item_group"
+			"insert_after": "subsidiary_address"
+		},
+		{
+			"fieldname": "column_break_pvhea",
+			"fieldtype": "Column Break",
+			"insert_after": "quotation_label",
+		},
+		{
+			"label": "Sales Order Type",
+			"fieldname": "sales_order_type",
+			"fieldtype": "Select",
+			"options": "\nFirst Sale\nFollow-Up Sale\nReoccuring Maintenance\nRTO\nSubscription Annual\nInternal Clearance\nOther",
+			"default": "",
+			"insert_after": "column_break_pvhea"
+		},
+		{
+			"label": "Software Maintenance",
+			"fieldname": "software_maintenance",
+			"fieldtype": "Link",
+			"options": "Software Maintenance",
+			"insert_after": "sales_order_type",
+		},
+		{
+			"label": "Item Group",
+			"fieldname": "item_group",
+			"fieldtype": "Link",
+			"options": "Item Group",
+			"insert_after": "software_maintenance"
+		},
+		{
+			"fieldname": "column_break_fdgxg",
+			"fieldtype": "Column Break",
+			"insert_after": "item_group",
 		},
 		{
 			"label": "Performance Period Start",
 			"fieldname": "performance_period_start",
 			"fieldtype": "Date",
 			"description": "Muss gefüllt werden wenn Wartungspositionen in Auftrag gehen.",
-			"insert_after": "quotation_label",
-		},
-		{
-			"fieldname": "column_break_fdgxg",
-			"fieldtype": "Column Break",
-			"insert_after": "performance_period_start",
-		},
-  		{
-			"label": "Software Maintenance",
-			"fieldname": "software_maintenance",
-			"fieldtype": "Link",
-			"options": "Software Maintenance",
 			"insert_after": "column_break_fdgxg",
 		},
 		{
@@ -698,7 +714,7 @@ def get_custom_fields():
 			"fieldname": "performance_period_end",
 			"fieldtype": "Date",
 			"description": "Muss gefüllt werden wenn Wartungspositionen in Auftrag gehen.",
-			"insert_after": "software_maintenance",
+			"insert_after": "performance_period_start",
 		},
   		{
 			"label": "Assigned to",
@@ -710,7 +726,7 @@ def get_custom_fields():
 			"insert_after": "performance_period_end"
 		},
 		{
-			"label": "Ihr Ansprechpartner",
+			"label": "Your Contact",
 			"fieldname": "ihr_ansprechpartner",
 			"fieldtype": "Link",
 			"options": "Employee",

--- a/simpatec/public/js/quotation.js
+++ b/simpatec/public/js/quotation.js
@@ -130,6 +130,16 @@ frappe.ui.form.on('Quotation', {
 			// Add Conditional Mandatory On Start/End Dates
 			frm.events.start_end_date_conditional_mandatory(frm)
 		}
+
+		frm.set_query('customer_subsidiary', function () {
+			if (!is_null(cur_frm.doc.party_name)) {
+				return {
+					filters: [
+						['Customer Subsidiary', 'customer', '=', frm.doc.party_name]
+					]
+				};
+			}
+		});
     },
 	setup: function(frm){
 		frm.set_query("anschreiben_vorlage", () => {


### PR DESCRIPTION
## **Pull Request Description Template:**

### **Description**

This pull request introduces changes to `Simpatec` section break, to `Quotation` doctype. The work includes the creation of a new field, adding the field to a new section for better layout.

### **Key changes:**
- Added Github PR format
- **SimpaTec** is a **Section Break** to organize related fields, and **Column Breaks** improve form layout and readability.  
- **Customer Subsidiary** links to the **Customer Subsidiary** doctype, and the field has filter of customer, but when creating from **Opportunity** the **Customer Subsidiary** value comes from **Opportunity** doctype
- **Subsidiary Address** is auto-fetched from the linked subsidiary
- **Customer Address** is now auto fetching billing address from  **Customer Subsidiary** and serves as the primary address of the customer

### **Related issue(s)/ticket(s):**
* [Gitlab Parent Issue](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/133)
* [GitLab Issue](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/153)
* [Mattermost Thread](https://chat.phamos.eu/phamos/pl/kbyeeoxwh7ycpfxs9ca9zwzykw)

### **Testing done:**  

- **Field Creation:** Verified that the new custom fields are successfully added to the **Quotation** doctype and appear correctly in the form.  
- **Data Fetching:** Ensured that **Subsidiary Address** is auto-fetched from the linked **Customer Subsidiary** and **Customer address** is fetching from **Customer Subsidiary** from the field **Billing Address**.
**Column Breaks** improve form layout for better usability.

### **Screenshots & GIFs (if applicable):**

* ![quotation_reorder](https://github.com/user-attachments/assets/20b6183b-55c4-43b3-995b-96d0850df947)




### **Further comments/notes:**

* Migration Required

### **Checklist:**

* [x] I have performed a self-review of my code.
* [ ] I have added or updated unit tests.
* [ ] I have updated the documentation (if necessary).
* [x] I have followed the project's coding style guidelines.
