### PR TITLE
Sales invoice/ Sales order doctype enhancements

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -94,8 +94,11 @@ def make_software_maintenance(source_name, target_doc=None):
 def update_internal_clearance_status(doc, handler=None):
 	if doc.sales_order_type == "Internal Clearance":
 		for item in doc.items:
-			internal_so = doc.sales_order_clearances[item.idx - 1].get("sales_order")
-			frappe.db.set_value(doc.doctype, internal_so, "clearance_status", "Cleared")
+			if len(doc.sales_order_clearances) > 0:
+				internal_so = doc.sales_order_clearances[item.idx - 1].get("sales_order")
+				frappe.db.set_value(doc.doctype, internal_so, "clearance_status", "Cleared")
+			else:
+				frappe.throw("Sales Order Type 'Internal Clearance' is selected, the sales order clearance cannot be empty.")
 
 
 def update_software_maintenance(doc, method=None):

--- a/simpatec/fixtures/property_setter.json
+++ b/simpatec/fixtures/property_setter.json
@@ -96,5 +96,22 @@
   "property_type": "Text",
   "row_name": null,
   "value": "This address is the Subsidiary Address fetched from the Customer Subsidiary."
+ },
+ {
+  "default_value": null,
+  "doc_type": "Sales Invoice",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "customer_section",
+  "modified": "2025-03-06 04:18:48.690715",
+  "name": "Sales Invoice-customer_section-label",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "property": "label",
+  "property_type": "Data",
+  "row_name": null,
+  "value": "Sales Invoice"
  }
 ]

--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -238,7 +238,8 @@ fixtures = [
 					"Sales Invoice-payment_terms_template-fetch_from",
                     "Sales Order-software_maintenance-no_copy",
                     "Quotation-customer_address-fetch_from",
-                    "Quotation-customer_address-description"
+                    "Quotation-customer_address-description",
+					"Sales Invoice-customer_section-label",
 				)
 			]
 		]

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -123,12 +123,48 @@ def get_custom_fields():
 			"fieldtype": "Section Break",
 		},	
 		{
+			"label": "Customer Subsidiary",
+			"fieldname": "customer_subsidiary",
+			"fieldtype": "Link",
+			"options": "Customer Subsidiary",
+			"reqd":1,
+			"insert_after": "simpatec_section"
+		},
+		{
+			"label": "Subsidiary Address",
+			"fieldname": "subsidiary_address",
+			"fieldtype": "Link",
+   			"options": "Address",
+			"fetch_from": "customer_subsidiary.subsidiary_address",
+      		"description": "This address will be fetched from the linked Customer Subsidiary and is the main address throughout the sales process.\nERPNext's standard address fields will be used for billing and shipping only.",
+			"fetch_if_empty": 1,
+   			"insert_after": "customer_subsidiary"
+		},
+  		{
+			"label": "Quotation Label",
+			"fieldname": "quotation_label",
+			"fieldtype": "Link",
+			"options": "Angebotsvorlage",
+			"insert_after": "subsidiary_address"
+		},
+		{
+			"label": "UID",
+			"fieldname": "uid",
+			"fieldtype": "Data",
+			"insert_after": "quotation_label"
+		},
+		{
+			"fieldname": "column_break_pvhea",
+			"fieldtype": "Column Break",
+			"insert_after": "uid",
+		},
+		{
 			"label": "Sales Order Type",
 			"fieldname": "sales_order_type",
 			"fieldtype": "Select",
 			"options": "\nFirst Sale\nFollow-Up Sale\nReoccuring Maintenance\nRTO\nSubscription Annual\nInternal Clearance\nOther",
 			"default": "",
-			"insert_after": "simpatec_section"
+			"insert_after": "column_break_pvhea"
 		},
 		{
 			"label": "Eligable for Clearance",
@@ -139,51 +175,39 @@ def get_custom_fields():
 			"insert_after": "sales_order_type",
 		},
 		{
+			"label": "Internal Clearance Details",
+			"fieldname": "internal_clearance_details",
+			"fieldtype": "Link",
+			"options": "Internal Clearance Details",
+			"allow_on_submit": 1,
+			"depends_on": "eval:doc.sales_order_type != \"Internal Clearance\" && doc.eligable_for_clearance == 1 && doc.sales_order_type != \"\"",
+			"insert_after": "eligable_for_clearance",
+		},
+		{
 			"label": "Item Group",
 			"fieldname": "item_group",
 			"fieldtype": "Link",
 			"options": "Item Group",
-			"insert_after": "eligable_for_clearance"
+			"insert_after": "internal_clearance_details"
 		},
 		{
-			"label": "Quotation Label",
-			"fieldname": "quotation_label",
-			"fieldtype": "Link",
-			"options": "Angebotsvorlage",
-			"insert_after": "item_group"
+			"fieldname": "column_break_fdgxg",
+			"fieldtype": "Column Break",
+			"insert_after": "item_group",
 		},
 		{
 			"label": "Performance Period Start",
 			"fieldname": "performance_period_start",
 			"fieldtype": "Date",
 			"description": "Muss gefüllt werden wenn Wartungspositionen in Auftrag gehen.",
-			"insert_after": "quotation_label",
-		},
-		{
-			"fieldname": "column_break_fdgxg",
-			"fieldtype": "Column Break",
-			"insert_after": "performance_period_start",
-		},
-		{
-			"label": "UID",
-			"fieldname": "uid",
-			"fieldtype": "Data",
-			"insert_after": "column_break_fdgxg"
-		},
-		{
-			"label": "Customer Subsidiary",
-			"fieldname": "customer_subsidiary",
-			"fieldtype": "Link",
-			"options": "Customer Subsidiary",
-			"reqd":1,
-			"insert_after": "uid"
+			"insert_after": "column_break_fdgxg",
 		},
 		{
 			"label": "Performance Period End",
 			"fieldname": "performance_period_end",
 			"fieldtype": "Date",
 			"description": "Muss gefüllt werden wenn Wartungspositionen in Auftrag gehen.",
-			"insert_after": "customer_subsidiary",
+			"insert_after": "performance_period_start",
 		},
 		{
 			"label": "Assigned to",
@@ -195,11 +219,12 @@ def get_custom_fields():
 			"insert_after": "performance_period_end"
 		},
 		{
-			"label": "Ihr Ansprechpartner",
+			"label": "Your Contact",
 			"fieldname": "ihr_ansprechpartner",
 			"fieldtype": "Link",
 			"options": "Employee",
 			"reqd":1,
+   			"fetch_if_empty":1,
 			"insert_after": "assigned_to"
 		},
 		{
@@ -218,15 +243,6 @@ def get_custom_fields():
 			"insert_after": "internal_clearance"
 		},
 		{
-			"label": "Internal Clearance Details",
-			"fieldname": "internal_clearance_details",
-			"fieldtype": "Link",
-			"options": "Internal Clearance Details",
-			"allow_on_submit": 1,
-			"depends_on": "eval:doc.sales_order_type != \"Internal Clearance\" && doc.eligable_for_clearance == 1 && doc.sales_order_type != \"\"",
-			"insert_after": "sales_order_clearances",
-		},
-		{
 			"label": "Purchase Order Total",
 			"fieldname": "po_total",
 			"fieldtype": "Currency",
@@ -234,7 +250,7 @@ def get_custom_fields():
 			"no_copy": 1,
 			"allow_on_submit": 1,
 			"depends_on": "eval:doc.sales_order_type != \"Internal Clearance\" && doc.eligable_for_clearance == 1 && doc.sales_order_type != \"\"",
-			"insert_after": "internal_clearance_details",
+			"insert_after": "sales_order_clearances",
 		},
 		{
 			"label": "Sales Order Margin",

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -151,6 +151,7 @@ def get_custom_fields():
 			"label": "UID",
 			"fieldname": "uid",
 			"fieldtype": "Data",
+			"fetch_from": "subsidiary_address.uid",
 			"insert_after": "quotation_label"
 		},
 		{
@@ -527,18 +528,199 @@ def get_custom_fields():
 
 	custom_fields_si = [
 		{
+			"label": "SimpaTec",
+			"fieldname": "simpatec_section",
+			"fieldtype": "Section Break",
+		},	
+		{
+			"label": "Main Customer Contact",
+			"fieldname": "billing_contact",
+			"fieldtype": "Link",
+			"options": "Contact",
+			"fetch_from": "customer_subsidiary.main_customer_contact",
+			"fetch_if_empty": 1,
+			"insert_after": "simpatec_section"
+		},
+		{
+			"label": "Billing Type",
+			"fieldname": "billing_type",
+			"fieldtype": "Select",
+			"options": "\nPaper Mail\nE-Mail\nSupplier Portal",
+			"fetch_from": "customer_subsidiary.billing_type",
+			"fetch_if_empty": 1,
+			"insert_after": "billing_contact"
+		},
+		{
+			"label": "Billing Email ID",
+			"fieldname": "billing_email_id",
+			"fieldtype": "Data",
+			"options": "Email",
+			"fetch_from": "customer_subsidiary.billing_email_id",
+			"fetch_if_empty": 1,
+			"description": "Works comma seperated. E.g. billing1@asdf.de,billing2@trgd.de/ fetch from customer subsidiary",
+			"insert_after": "billing_type"
+		},
+		{
+			"fieldname": "column_break_nmrk4",
+			"fieldtype": "Column Break",
+			"insert_after": "billing_email_id",
+		},
+		{
+			"label": "Supplier Number",
+			"fieldname": "supplier_number",
+			"fieldtype": "Data",
+			"fetch_from": "customer.supplier_number",
+			"description": "Wird vom Kunden übermittelt",
+			"insert_after": "column_break_nmrk4"
+		},
+		{
+			"label": "Supplier Portal",
+			"fieldname": "supplier_portal",
+			"fieldtype": "Data",
+			"fetch_from": "customer_subsidiary.supplier_portal",
+			"mandatory_depends_on": "eval:doc.billing_type=='Supplier Portal'",
+			"translatable": 1,
+			"insert_after": "supplier_number"
+		},
+		{
+			"fieldname": "column_break_nszzd",
+			"fieldtype": "Column Break",
+			"insert_after": "supplier_portal",
+		},
+		{
+			"label": "Delivery Date",
+			"fieldname": "delivery_date",
+			"fieldtype": "Date",
+			"insert_after": "column_break_nszzd"
+		},
+		{
+			"label": "Editor at your agency",
+			"fieldname": "bearbeiter_in_ihrem_hause",
+			"fieldtype": "Link",
+			"options": "Contact",
+			"description": "Bestellung wird beim Kunden bearbeitet von",
+			"insert_after": "delivery_date"
+		},
+		{
+			"label": "Print article description",
+			"fieldname": "print_article_description",
+			"fieldtype": "Check",
+			"insert_after": "bearbeiter_in_ihrem_hause"
+		},
+		{
+			"label": "",
+			"fieldname": "simpatec_section_2",
+			"fieldtype": "Section Break",
+			"insert_after": "print_article_description"
+		},
+		{
+			"label": "Customer Subsidiary",
+			"fieldname": "customer_subsidiary",
+			"fieldtype": "Link",
+			"options": "Customer Subsidiary",
+			"mandatory_depends_on": "eval:doc.status == 'Draft'",
+			"insert_after": "simpatec_section_2"
+		},
+		{
+			"label": "Subsidiary Address",
+			"fieldname": "subsidiary_address",
+			"fieldtype": "Link",
+   			"options": "Address",
+			"fetch_from": "customer_subsidiary.subsidiary_address",
+      		"description": "This address will be fetched from the linked Customer Subsidiary and is the main address throughout the sales process.\nERPNext's standard address fields will be used for billing and shipping only.",
+			"fetch_if_empty": 1,
+   			"insert_after": "customer_subsidiary"
+		},
+  		{
+			"label": "Quotation Label",
+			"fieldname": "quotation_label",
+			"fieldtype": "Link",
+			"options": "Angebotsvorlage",
+			"in_list_view": 1,
+			"insert_after": "subsidiary_address"
+		},
+		{
+			"label": "UID",
+			"fieldname": "uid",
+			"fieldtype": "Data",
+			"fetch_from": "subsidiary_address.uid",
+   			"fetch_if_empty": 1,
+			"insert_after": "quotation_label"
+		},
+		{
+			"fieldname": "column_break_pvhea",
+			"fieldtype": "Column Break",
+			"insert_after": "uid",
+		},
+		{
+			"label": "Order Type",
+			"fieldname": "order_type",
+			"fieldtype": "Select",
+			"options": "\nSales\nMaintenance\nShopping Cart",
+			"default": "",
+			"insert_after": "column_break_pvhea"
+		},
+		{
+			"label": "Item Group",
+			"fieldname": "item_group",
+			"fieldtype": "Link",
+			"options": "Item Group",
+			"allow_on_submit": 1,
+			"insert_after": "order_type"
+		},
+		{
+			"fieldname": "column_break_fdgxg",
+			"fieldtype": "Column Break",
+			"insert_after": "item_group",
+		},
+		{
+			"label": "Performance Period Start",
+			"fieldname": "performance_period_start",
+			"fieldtype": "Date",
+			"description": "Muss gefüllt werden wenn Wartungspositionen in Auftrag gehen.",
+			"insert_after": "column_break_fdgxg",
+		},
+		{
+			"label": "Performance Period End",
+			"fieldname": "performance_period_end",
+			"fieldtype": "Date",
+			"description": "Muss gefüllt werden wenn Wartungspositionen in Auftrag gehen.",
+			"in_list_view": 1,
+			"insert_after": "performance_period_start",
+		},
+		{
+			"label": "Assigned to",
+			"fieldname": "assigned_to",
+			"fieldtype": "Link",
+			"options": "User",
+			"fetch_from": "customer_subsidiary.assigned_to",
+			"fetch_if_empty":1,
+			"reqd": 1,
+			"insert_after": "performance_period_end"
+		},
+		{
+			"label": "Your Contact",
+			"fieldname": "ihr_ansprechpartner",
+			"fieldtype": "Link",
+			"options": "Employee",
+   			"fetch_if_empty":1,
+			"ignore_user_permissions": 1,
+			"insert_after": "assigned_to"
+		},
+		{
+			"label": "Vollständinger Name",
+			"fieldname": "vollständinger_name",
+			"fieldtype": "Data",
+			"fetch_from": "ihr_ansprechpartner.employee_name",
+			"read_only": 1,
+			"insert_after": "ihr_ansprechpartner"
+		},
+		{
 			"label": "Software Maintenance",
 			"fieldname": "software_maintenance",
 			"fieldtype": "Link",
 			"options": "Software Maintenance",
 			"insert_after": "accounting_dimensions_section",
-		},
-  		{
-			"label": "Customer Subsidiary",
-			"fieldname": "customer_subsidiary",
-			"fieldtype": "Link",
-			"options": "Customer Subsidiary",
-			"insert_after": "customer_name",
 		},
 	]
 

--- a/simpatec/public/js/sales_order.js
+++ b/simpatec/public/js/sales_order.js
@@ -90,6 +90,15 @@ frappe.ui.form.on('Sales Order', {
             $("div[data-fieldname='sales_order_clearances']").parents(".form-column").removeClass("col-md-12")
         }
 
+        frm.set_query('customer_subsidiary', function () {
+            if (!is_null(cur_frm.doc.customer)) {
+                return {
+                    filters: [
+                        ['Customer Subsidiary', 'customer', '=', frm.doc.customer]
+                    ]
+                };
+            }
+        });
     },
 
     internal_clearance_details: function(frm){


### PR DESCRIPTION
### **Description**

- This pull request introduces changes to `Sales Invoice` doctype, including updates to fields for customer subsidiary information, billing details, and order management, with user-editable options and improved UI layout.
- Additionally Added A condition in `Sales Order` when updating Clearance Status on Sales Orde Clearance table, previously it was crashing the system if Sales Order Type is `Internal Clearance` and we dont have any data in the table and submits the sales order, now it shows the message


### **Key changes:**
1. Added **SimpaTec** section.
2. Fetched **Main Customer Contact**, **Billing Type**, and **Billing Email ID** from *Customer Subsidiary*, editable by user.
3. Fetched **Supplier Number** from *Customer*.
4. **Supplier Portal** conditionally mandatory based on **Billing Type**.
5. Set **Delivery Date** by user, description removed.
6. Added **Editor at Your Agency** (link to contact) and **Print Article Description** (checkbox).
7. Created new **Customer Subsidiary Section** with related fields.
8. Fetched **Subsidiary Address** and **UID** from *Customer Subsidiary*.
9. Added **Order Type**, **Item Group**, **Performance Period Start/End**, and **Assigned to** (fetched from *Customer Subsidiary*).
10. Added **Your Contact** (link to employee) and **Full Name** (read-only).
11. Added conditional statement while updating sales order clearance `Sales Order Type 'Internal Clearance' is selected, the sales order clearance cannot be empty.`

### **Related issue(s)/ticket(s):**
* [Gitlab Parent Issue](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/133)
* [GitLab Issue](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/155)
* [Mattermost Thread](https://chat.phamos.eu/phamos/pl/ha7gxe1kgprfxfb44b5eb77uhr)

* [GITLAB ISSUE (Sales Order Clearance)](https://git.phamos.eu/simpatec/P-0142Marketing/-/work_items/72)
* [GITLAB PARENT ISSUE (Sales Order Clearance)](https://git.phamos.eu/simpatec/P-0142Marketing/-/issues/69)

### **Testing done:**  

#### Sales Invoice 
- **Field Creation:**  
  - Verified that new fields are added successfully to **Sales Invoice** doctype and displayed correctly in the form.  

- **Data Fetching:**  
  - Ensured the values which are coming from Sales Order are copied into the Sales invoice fields. 
  - Ensured **Subsidiary Address** is auto-fetched from **Customer Subsidiary**.  
  - Verified **Billing Email ID** and **Supplier Portal** are fetched from **Customer Subsidiary** and are editable.

- **Form Layout & UI Improvements:**  
  - Checked that **Column Breaks** and field reordering improve form readability and usability.  
  - Ensured fields align logically for better data entry flow.

- **Dependency & Conditional Logic:**  
  - Verified fields such as **Supplier Portal** are conditionally visible based on **Billing Type**.

#### Sales Order
- Now system is showing message before submit that Sales order Clearance table cannot be empty is Sales Order type is Internal Clearance is selected

### **Screenshots & GIFs (if applicable):**

**Sales Invoice**
* ![salesinvoice_reorder](https://github.com/user-attachments/assets/59644cba-5a30-4f82-a82c-23b2dfc4005f)

**Sales Order**
* ![soc](https://github.com/user-attachments/assets/2e634c56-29e6-4a1b-a14a-2fd79eecf002)



### **Further comments/notes:**

* Migration Required

### **Checklist:**

* [x] I have performed a self-review of my code.
* [ ] I have added or updated unit tests.
* [ ] I have updated the documentation (if necessary).
* [x] I have followed the project's coding style guidelines.
