### PR TITLE
Main Customer Contact Field to sales flow

### DIFF
--- a/simpatec/events/sales_order.py
+++ b/simpatec/events/sales_order.py
@@ -6,6 +6,11 @@ from frappe.model.mapper import get_mapped_doc
 from datetime import date, timedelta, datetime
 from dateutil.relativedelta import relativedelta
 from six import string_types
+from frappe.contacts.doctype.address.address import get_company_address
+from frappe.model.utils import get_fetch_values
+from erpnext.accounts.party import get_party_account
+from erpnext.stock.doctype.item.item import get_item_defaults
+from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 
 @frappe.whitelist()
 def validate(doc, handler=None):
@@ -506,3 +511,94 @@ def validate_maintenance_amount(doc):
 			row = "".join(row)
 			msg = f"{_('One or more maintenance items in the Sales Order Item table have an amount that is less than or equal to 0.00. Please review these items to ensure this is correct.')} <ul >{row}</ul>"
 			frappe.msgprint(msg, title=_("Warning: Invalid Maintenance Amount"))
+   
+
+@frappe.whitelist()
+def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
+	def postprocess(source, target):
+		set_missing_values(source, target)
+		# Get the advance paid Journal Entries in Sales Invoice Advance
+		if target.get("allocate_advances_automatically"):
+			target.set_advances()
+
+	def set_missing_values(source, target):
+		target.flags.ignore_permissions = True
+		target.run_method("set_missing_values")
+		target.run_method("set_po_nos")
+		target.run_method("calculate_taxes_and_totals")
+
+		if source.company_address:
+			target.update({"company_address": source.company_address})
+		else:
+			# set company address
+			target.update(get_company_address(target.company))
+
+		if target.company_address:
+			target.update(get_fetch_values("Sales Invoice", "company_address", target.company_address))
+
+		# set the redeem loyalty points if provided via shopping cart
+		if source.loyalty_points and source.order_type == "Shopping Cart":
+			target.redeem_loyalty_points = 1
+
+		target.debit_to = get_party_account("Customer", source.customer, source.company)
+
+	def update_item(source, target, source_parent):
+		target.amount = flt(source.amount) - flt(source.billed_amt)
+		target.base_amount = target.amount * flt(source_parent.conversion_rate)
+		target.qty = (
+			target.amount / flt(source.rate)
+			if (source.rate and source.billed_amt)
+			else source.qty - source.returned_qty
+		)
+
+		if source_parent.project:
+			target.cost_center = frappe.db.get_value("Project", source_parent.project, "cost_center")
+		if target.item_code:
+			item = get_item_defaults(target.item_code, source_parent.company)
+			item_group = get_item_group_defaults(target.item_code, source_parent.company)
+			cost_center = item.get("selling_cost_center") or item_group.get("selling_cost_center")
+
+			if cost_center:
+				target.cost_center = cost_center
+
+	doclist = get_mapped_doc(
+		"Sales Order",
+		source_name,
+		{
+			"Sales Order": {
+				"doctype": "Sales Invoice",
+				"field_map": {
+					"party_account_currency": "party_account_currency",
+					"payment_terms_template": "payment_terms_template",
+					"main_customer_contact":"billing_contact"
+				},
+				"field_no_map": ["payment_terms_template"],
+				"validation": {"docstatus": ["=", 1]},
+			},
+			"Sales Order Item": {
+				"doctype": "Sales Invoice Item",
+				"field_map": {
+					"name": "so_detail",
+					"parent": "sales_order",
+				},
+				"postprocess": update_item,
+				"condition": lambda doc: doc.qty
+				and (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount)),
+			},
+			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "add_if_empty": True},
+			"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
+		},
+		target_doc,
+		postprocess,
+		ignore_permissions=ignore_permissions,
+	)
+
+	automatically_fetch_payment_terms = cint(
+		frappe.db.get_single_value("Accounts Settings", "automatically_fetch_payment_terms")
+	)
+	if automatically_fetch_payment_terms:
+		doclist.set_payment_schedule()
+
+	doclist.set_onload("ignore_price_list", True)
+
+	return doclist

--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -137,7 +137,8 @@ scheduler_events = {
 #
 override_whitelisted_methods = {
 	"erpnext.selling.doctype.sales_order.sales_order.make_purchase_order_for_default_supplier": "simpatec.events.sales_order.make_purchase_order_for_default_supplier",
-	"erpnext.selling.doctype.sales_order.sales_order.make_purchase_order": "simpatec.events.sales_order.make_purchase_order"
+	"erpnext.selling.doctype.sales_order.sales_order.make_purchase_order": "simpatec.events.sales_order.make_purchase_order",
+	"erpnext.selling.doctype.sales_order.sales_order.make_sales_invoice": "simpatec.events.sales_order.make_sales_invoice",
 }
 #
 # each overriding function accepts a `data` argument;

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -131,6 +131,15 @@ def get_custom_fields():
 			"insert_after": "simpatec_section"
 		},
 		{
+			"label": "Main Customer Contact",
+			"fieldname": "main_customer_contact",
+			"fieldtype": "Link",
+   			"options": "Contact",
+			"fetch_from": "customer_subsidiary.main_customer_contact",
+			"fetch_if_empty": 1,
+			"insert_after": "customer_subsidiary"
+		},
+		{
 			"label": "Subsidiary Address",
 			"fieldname": "subsidiary_address",
 			"fieldtype": "Link",
@@ -138,7 +147,7 @@ def get_custom_fields():
 			"fetch_from": "customer_subsidiary.subsidiary_address",
       		"description": "This address will be fetched from the linked Customer Subsidiary and is the main address throughout the sales process.\nERPNext's standard address fields will be used for billing and shipping only.",
 			"fetch_if_empty": 1,
-   			"insert_after": "customer_subsidiary"
+   			"insert_after": "main_customer_contact"
 		},
   		{
 			"label": "Quotation Label",
@@ -531,15 +540,6 @@ def get_custom_fields():
 			"label": "SimpaTec",
 			"fieldname": "simpatec_section",
 			"fieldtype": "Section Break",
-		},	
-		{
-			"label": "Main Customer Contact",
-			"fieldname": "billing_contact",
-			"fieldtype": "Link",
-			"options": "Contact",
-			"fetch_from": "customer_subsidiary.main_customer_contact",
-			"fetch_if_empty": 1,
-			"insert_after": "simpatec_section"
 		},
 		{
 			"label": "Billing Type",
@@ -548,7 +548,7 @@ def get_custom_fields():
 			"options": "\nPaper Mail\nE-Mail\nSupplier Portal",
 			"fetch_from": "customer_subsidiary.billing_type",
 			"fetch_if_empty": 1,
-			"insert_after": "billing_contact"
+			"insert_after": "simpatec_section"
 		},
 		{
 			"label": "Billing Email ID",
@@ -622,6 +622,15 @@ def get_custom_fields():
 			"insert_after": "simpatec_section_2"
 		},
 		{
+			"label": "Main Customer Contact",
+			"fieldname": "billing_contact",
+			"fieldtype": "Link",
+			"options": "Contact",
+			"fetch_from": "customer_subsidiary.main_customer_contact",
+			"fetch_if_empty": 1,
+			"insert_after": "customer_subsidiary"
+		},
+		{
 			"label": "Subsidiary Address",
 			"fieldname": "subsidiary_address",
 			"fieldtype": "Link",
@@ -629,7 +638,7 @@ def get_custom_fields():
 			"fetch_from": "customer_subsidiary.subsidiary_address",
       		"description": "This address will be fetched from the linked Customer Subsidiary and is the main address throughout the sales process.\nERPNext's standard address fields will be used for billing and shipping only.",
 			"fetch_if_empty": 1,
-   			"insert_after": "customer_subsidiary"
+   			"insert_after": "billing_contact"
 		},
   		{
 			"label": "Quotation Label",
@@ -852,6 +861,15 @@ def get_custom_fields():
 			"insert_after": "simpatec_section",
 		},
 		{
+			"label": "Main Customer Contact",
+			"fieldname": "main_customer_contact",
+			"fieldtype": "Link",
+   			"options": "Contact",
+			"fetch_from": "customer_subsidiary.main_customer_contact",
+			"fetch_if_empty": 1,
+			"insert_after": "customer_subsidiary"
+		},
+		{
 			"label": "Subsidiary Address",
 			"fieldname": "subsidiary_address",
 			"fieldtype": "Link",
@@ -859,7 +877,7 @@ def get_custom_fields():
 			"fetch_from": "customer_subsidiary.subsidiary_address",
       		"description": "This address will be fetched from the linked Customer Subsidiary and is the main address throughout the sales process.\nERPNext's standard address fields will be used for billing and shipping only.",
 			"fetch_if_empty": 1,
-   			"insert_after": "customer_subsidiary"
+   			"insert_after": "main_customer_contact"
 		},
 		{
 			"label": "Quotation Label",
@@ -1113,6 +1131,15 @@ def get_custom_fields():
 			"insert_after": "simpatec"
 		},
 		{
+			"label": "Main Customer Contact",
+			"fieldname": "main_customer_contact",
+			"fieldtype": "Link",
+   			"options": "Contact",
+			"fetch_from": "customer_subsidiary.main_customer_contact",
+			"fetch_if_empty": 1,
+			"insert_after": "customer_subsidiary"
+		},
+		{
 			"label": "Subsidiary Address",
 			"fieldname": "subsidiary_address",
 			"fieldtype": "Link",
@@ -1120,7 +1147,7 @@ def get_custom_fields():
 			"fetch_from": "customer_subsidiary.subsidiary_address",
       		"description": "This address will be fetched from the linked Customer Subsidiary and is the main address throughout the sales process.\nERPNext's standard address fields will be used for billing and shipping only.",
 			"fetch_if_empty": 1,
-   			"insert_after": "customer_subsidiary"
+   			"insert_after": "main_customer_contact"
 		},
 		{
 			"fieldname": "column_break_pvhea",


### PR DESCRIPTION
## Description
- Now we have `Main Customer Contact `field to [**`Opportunity`, `Quotation`, `Sales Order`, `Sales Invoice`**] (Sales Flow)

**Key changes:**
* Added Main Customer Contact below the Customer Subsidairy field in the above Sales Flow doctypes
* Main Customer Contact field fetched the values from Customer Subsidairy doctype
* Main Customer Contact will not fetch the value if there is a value in it.

**Related issue(s)/ticket(s):**

* GitLab Issue: https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/159
* Gitlab Parent Issue: https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/133
* Mattermost Thread: https://chat.phamos.eu/phamos/pl/emtug3gc3byepyk1xkb1jyghmr

**Testing done:**
* Checked Main Customer Contact field is fetching value correct and not fetching value if there is a value in it.

**Screenshots & GIFs (if applicable):**

* Opportunity 
<img width="800" alt="Screenshot 2025-03-10 at 17 08 16" src="https://github.com/user-attachments/assets/8898719c-a277-4dbf-9b79-f2b019be5e8f" />

* Quotation
<img width="805" alt="Screenshot 2025-03-10 at 17 08 04" src="https://github.com/user-attachments/assets/cad57452-72c7-41cf-84b6-57e975f8df18" />

* Sales Order
<img width="816" alt="Screenshot 2025-03-10 at 17 07 45" src="https://github.com/user-attachments/assets/1a111ded-8de5-4aa0-b072-c75422924d39" />

* Sales Invoice
<img width="808" alt="Screenshot 2025-03-10 at 17 07 33" src="https://github.com/user-attachments/assets/27a8021b-97bf-4922-bad6-db20f317d0ec" />


**Further comments/notes (optional):**

* MIGRATION REQUIRED

**Checklist:**

* [x] I have performed a self-review of my code.
* [ ] I have added or updated unit tests.
* [ ] I have updated the documentation (if necessary).
* [x] I have followed the project's coding style guidelines.