### PR TITLE
Dunning doctype customer subsidairy enhancements

### DIFF
--- a/simpatec/hooks.py
+++ b/simpatec/hooks.py
@@ -39,6 +39,7 @@ doctype_js = {
 	"Opportunity": "public/js/opportunity.js",
 	"Purchase Order" : "public/js/purchase_order.js",
 	"Sales Invoice" : "public/js/sales_invoice.js",
+	"Dunning" : "public/js/dunning.js",
 }
 doctype_list_js = {"Purchase Order" : "public/js/purchase_order_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/simpatec/install.py
+++ b/simpatec/install.py
@@ -1192,6 +1192,41 @@ def get_custom_fields():
 		},
 		
 	]
+ 
+ 
+	custom_fields_dunning = [
+		{
+			"label": "SimpaTec",
+			"fieldname": "simpatec_section",
+			"fieldtype": "Section Break",
+		},	
+		{
+			"label": "Customer Subsidiary",
+			"fieldname": "customer_subsidiary",
+			"fieldtype": "Link",
+			"options": "Customer Subsidiary",
+			"insert_after": "simpatec_section"
+		},
+		{
+			"label": "Quotation Label",
+			"fieldname": "quotation_label",
+			"fieldtype": "Link",
+			"options": "Angebotsvorlage",
+			"insert_after": "customer_subsidiary"
+		},
+		{
+			"label": "UID",
+			"fieldname": "uid",
+			"fieldtype": "Data",
+			"fetch_from": "subsidiary_address.uid",
+			"insert_after": "quotation_label"
+		},
+		{
+			"fieldname": "section_break_kiny4",
+			"fieldtype": "Section Break",
+			"insert_after": "uid"
+		},
+	]
 
 	return {
 		"Customer": custom_fields_customer,
@@ -1204,5 +1239,6 @@ def get_custom_fields():
 		"Purchase Order Item": custom_fields_poi,
 		"Quotation": custom_fields_quo,
 		"Quotation Item": custom_fields_quoi,
-		"Opportunity": custom_fields_opportunity
+		"Opportunity": custom_fields_opportunity,
+		"Dunning": custom_fields_dunning
 	}

--- a/simpatec/public/js/dunning.js
+++ b/simpatec/public/js/dunning.js
@@ -1,0 +1,14 @@
+frappe.ui.form.on('Dunning', {
+    refresh(frm) {
+        // Set the filter on the task field to show only tasks linked to the project
+        frm.set_query('customer_subsidiary', function () {
+            if (!is_null(cur_frm.doc.customer)) {
+                return {
+                    filters: [
+                        ['Customer Subsidiary', 'customer', '=', frm.doc.customer]
+                    ]
+                };
+            }
+        });
+    }
+})


### PR DESCRIPTION
## Description
This pull request introduces changes to add a section break, Simpatec, to the `Dunning doctype`. The work includes the creation of a new field related to `Customer Subsidairy`, adding the field to a new section for better layout.

**Key Changes:**  
- Added a **new section**: "SimpaTec" (`simpatec_section`).  
- Introduced **"Customer Subsidiary"** (`customer_subsidiary`) as a **Link** field referencing "Customer Subsidiary".  
- **Added a filter** on the `customer_subsidiary` field in the "Dunning" form.  
- Added **"Quotation Label"** (`quotation_label`) as a **Link** field referencing "Angebotsvorlage".  
- Implemented **"UID"** (`uid`) as a **Data** field, fetching value from `subsidiary_address.uid`.  


**Related issue(s)/ticket(s):**

* [GITLAB PARENT ISSUE](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/issues/173)
* [GITLAB ISSUE](https://git.phamos.eu/simpatec/erstauftrag-p-0109/-/work_items/160)
* [MATTERMOST THREAD](https://chat.phamos.eu/phamos/pl/37aecyj3sfyu3d87bihmg8gxac)

**Testing done:**

- **Field Creation:** Verified that the new custom fields are successfully added to the **Dunning** doctype and appear correctly in the form. .
- **Data Filtering:**  Ensures that only **Customer Subsidiary records linked to the selected Customer** are displayed.  

**Screenshots & GIFs:**
![dunning](https://github.com/user-attachments/assets/9d8616c4-7db9-4505-9e39-ca110263f84a)

**Further comments/notes (optional):**

* Migration Required

**Checklist:**

* [x] I have performed a self-review of my code.
* [ ] I have added or updated unit tests.
* [ ] I have updated the documentation (if necessary).
* [x] I have followed the project's coding style guidelines.